### PR TITLE
Fix/dm

### DIFF
--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -10,7 +10,7 @@ daemons:
       namespace: nnf-dm-system
   - name: client-mount
     bin: clientmount
-    repository: hpc-dpm-dws-operator
+    repository: dws
     path: mount-daemon
     skipNnfNodeName: true
     serviceAccount:


### PR DESCRIPTION
- Fix client mount daemon repository
- Virgin install bugs where `|| true` was incorrectly scoped
- New Nodes argument to install command to only install on specific compute nodes `install [<node> ...]`