### PR TITLE
RABSW-974 Let the lustre-csi-driver deployment default to lustre-capable

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -23,7 +23,7 @@ repositories:
     development: https://ghcr.io/hewlettpackard/dws
     master: https://ghcr.io/hewlettpackard/dws
   - name: lustre-csi-driver
-    overlays: [rabbit]
+    overlays: [rabbit, kind]
     development: https://ghcr.io/hewlettpackard/lustre-csi-driver
     master: https://ghcr.io/hewlettpackard/lustre-csi-driver
   - name: lustre-fs-operator


### PR DESCRIPTION
Update the repository file to find a "kind" overlay for lustre-csi-driver.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>