### PR TITLE
Use daemon removal option to properly remove existing service prior install

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,7 +289,6 @@ func (cmd *InstallCmd) Run(ctx *Context) error {
 						return err
 					}
 
-
 					fmt.Printf("  Installing %s service...", d.Name)
 					cmd = exec.Command("ssh", compute, "/usr/bin/"+d.Bin, "install", "|| true")
 					if err := runCommand(ctx, cmd); err != nil {

--- a/main.go
+++ b/main.go
@@ -278,8 +278,15 @@ func (cmd *InstallCmd) Run(ctx *Context) error {
 
 					fmt.Printf("  Installing %s on Compute Node %s\n", d.Name, compute)
 
+					fmt.Printf("  Stopping %s service...", d.Name)
+					cmd := exec.Command("ssh", compute, "systemctl", "stop", d.Bin, "|| true")
+					if err := runCommand(ctx, cmd); err != nil {
+						return err
+					}
+					fmt.Printf("\n")
+
 					fmt.Printf("  Removing %s service...", d.Name)
-					cmd := exec.Command("ssh", compute, "/usr/bin/"+d.Bin, "remove", "|| true")
+					cmd = exec.Command("ssh", compute, "/usr/bin/"+d.Bin, "remove", "|| true")
 					if err := runCommand(ctx, cmd); err != nil {
 						return err
 					}

--- a/main.go
+++ b/main.go
@@ -278,8 +278,8 @@ func (cmd *InstallCmd) Run(ctx *Context) error {
 
 					fmt.Printf("  Installing %s on Compute Node %s\n", d.Name, compute)
 
-					fmt.Printf("  Stopping service...")
-					cmd := exec.Command("ssh", compute, "systemctl", "stop", d.Bin, "|| true")
+					fmt.Printf("  Removing %s service...", d.Name)
+					cmd := exec.Command("ssh", compute, "/usr/bin/"+d.Bin, "remove", "|| true")
 					if err := runCommand(ctx, cmd); err != nil {
 						return err
 					}
@@ -288,6 +288,7 @@ func (cmd *InstallCmd) Run(ctx *Context) error {
 					if err := copyToNode(d.Bin, compute, "/usr/bin"); err != nil {
 						return err
 					}
+
 
 					fmt.Printf("  Installing %s service...", d.Name)
 					cmd = exec.Command("ssh", compute, "/usr/bin/"+d.Bin, "install", "|| true")


### PR DESCRIPTION
Failure to remove causes install to not install because of this snippet in the `Install()` call

```go
	if linux.isInstalled() {
		return installAction + failed, ErrAlreadyInstalled
	}
```

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>