### PR TITLE
Use quite mode when retrieving remote md5sum

### DIFF
--- a/main.go
+++ b/main.go
@@ -500,7 +500,7 @@ func checkNeedsUpdate(ctx *Context, name string, compute string, destination str
 	fmt.Printf("%s", src)
 
 	fmt.Printf("    Destination MD5: ")
-	dest, err := runCommand(ctx, exec.Command("ssh", compute, "md5sum "+path.Join(destination, name), " || true"))
+	dest, err := runCommand(ctx, exec.Command("ssh", "-q", compute, "md5sum "+path.Join(destination, name), " || true"))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Use quite mode (-q) when retrieving remote md5sum, thereby suppressing the connection message present on some systems (rabbit-dev-cn-*)

```
$ ssh rabbit-dev-cn-02 "md5sum /usr/bin/nnf-dm"
#=====================================================================
# This is a private computer facility. Access for any reason must be
# specifically authorized by HPE. Unless you are so authorized, your
# continued access and any other use may expose you to criminal
# and/or civil proceedings.
#
#=====================================================================
9bba9c591945046c7fb8aaa7c810722d  /usr/bin/nnf-dm
```

```
$ ssh -q rabbit-dev-cn-02 "md5sum /usr/bin/nnf-dm"
9bba9c591945046c7fb8aaa7c810722d  /usr/bin/nnf-dm
```

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>