### PR TITLE
Support for refactored lustre-csi-driver repo

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -23,7 +23,7 @@ repositories:
     development: https://ghcr.io/hewlettpackard/dws
     master: https://ghcr.io/hewlettpackard/dws
   - name: lustre-csi-driver
-    overlays: [rabbit, kind]
+    overlays: [overlays/rabbit, overlays/kind]
     development: https://ghcr.io/hewlettpackard/lustre-csi-driver
     master: https://ghcr.io/hewlettpackard/lustre-csi-driver
   - name: lustre-fs-operator

--- a/config/systems.yaml
+++ b/config/systems.yaml
@@ -2,7 +2,7 @@
 systems:
 - name: kind
   aliases: [kind-kind]
-  overlays: [kind]
+  overlays: [kind, overlays/kind]
   master: kind-control-plane
   workers:
   rabbits:
@@ -19,14 +19,14 @@ systems:
     rabbit-03:
 - name: rabbit-dev
   aliases: [dp0, rabbit-dev-01, rabbit-lab]
-  overlays: [dp0,rabbit]
+  overlays: [dp0,rabbit,overlays/rabbit]
   master: rabbit-dev-vm-k8s-master
   workers: [rabbit-dev-cn-02]
   rabbits:
     rabbit-dev-01: {0: rabbit-dev-cn-01, 1: rabbit-dev-cn-02, 2: rabbit-dev-cn-03, 3: rabbit-dev-cn-04}
 - name: rabbit-htx
   aliases: [dp1, dp1a]
-  overlays: [dp0,rabbit]
+  overlays: [dp0,rabbit,overlays/rabbit]
   master: rabbit-k8s-master
   workers: [rabbit-k8s-worker]
   rabbits:
@@ -34,7 +34,7 @@ systems:
     rabbit-node-1: {0: compute-node-3, 1: compute-node-2}   # These computes are physically swapped
 - name: rabbit-htx-2
   aliases: [htx-2]
-  overlays: [dp0,rabbit]
+  overlays: [dp0,rabbit,overlays/rabbit]
   master: compute-node-4
   workers: [compute-node-5]
   rabbits:

--- a/config/systems.yaml
+++ b/config/systems.yaml
@@ -10,7 +10,7 @@ systems:
     kind-worker2: {4: compute-04}
 - name: craystack-default
   aliases: [craystack]
-  overlays: [craystack,rabbit]
+  overlays: [craystack]
   master: k3s-master
   workers: [k3s-master]
   rabbits:
@@ -19,14 +19,14 @@ systems:
     rabbit-03:
 - name: rabbit-dev
   aliases: [dp0, rabbit-dev-01, rabbit-lab]
-  overlays: [dp0,rabbit,overlays/rabbit]
+  overlays: [dp0,overlays/rabbit]
   master: rabbit-dev-vm-k8s-master
   workers: [rabbit-dev-cn-02]
   rabbits:
     rabbit-dev-01: {0: rabbit-dev-cn-01, 1: rabbit-dev-cn-02, 2: rabbit-dev-cn-03, 3: rabbit-dev-cn-04}
 - name: rabbit-htx
   aliases: [dp1, dp1a]
-  overlays: [dp0,rabbit,overlays/rabbit]
+  overlays: [dp0,overlays/rabbit]
   master: rabbit-k8s-master
   workers: [rabbit-k8s-worker]
   rabbits:
@@ -34,7 +34,7 @@ systems:
     rabbit-node-1: {0: compute-node-3, 1: compute-node-2}   # These computes are physically swapped
 - name: rabbit-htx-2
   aliases: [htx-2]
-  overlays: [dp0,rabbit,overlays/rabbit]
+  overlays: [dp0,overlays/rabbit]
   master: compute-node-4
   workers: [compute-node-5]
   rabbits:


### PR DESCRIPTION
Modifies the necessary config files to support the [config file restructuring PR](https://github.com/HewlettPackard/lustre-csi-driver/pull/19) arriving in the lustre-csi-driver repository.

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>