### PR TITLE
Kind: Convert kind-config to use kubeadm configurations, v1.25.2, and cleanup

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -29,55 +29,65 @@ fi
 
 if [[ "$CMD" == "create" ]]; then
     CONFIG=kind-config.yaml
-    cat > $CONFIG << EOF
-# three node (two workers) cluster config
+
+    # Only write the config if it's not present; this allows customization 
+    if ! [[ -f "$CONFIG" ]]; then
+
+      # Rabbit & WLM System Local Controllers (SLC)
+      SLCCONFIG=$(cat << EOF
+
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: cray.nnf.manager=true,cray.wlm.manager=true
+EOF
+)
+
+      # Rabbit taints/labels, plus some host mounts for data movement
+      RABBITCONFIG=$(cat << EOF
+
+  extraMounts:
+    - hostPath: /tmp/nnf
+      containerPath: /nnf
+      propagation: None
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      taints:
+      - key: cray.nnf.node
+        value: "true"
+        effect: NoSchedule
+      kubeletExtraArgs:
+        node-labels: "cray.nnf.node=true"
+EOF
+)
+
+      cat > $CONFIG <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerAddress: "127.0.0.1"
 nodes:
 - role: control-plane
-- role: worker
-  extraMounts:
-  - hostPath: /tmp/nnf
-    containerPath: /nnf
-    propagation: None
-- role: worker
-  extraMounts:
-  - hostPath: /tmp/nnf
-    containerPath: /nnf
-    propagation: None
+- role: worker $SLCCONFIG
+- role: worker $RABBITCONFIG
+- role: worker $RABBITCONFIG
 EOF
 
+    fi
+
+    # create a file for data movement
     if [ ! -f /tmp/nnf/file.in ]; then
         mkdir -p /tmp/nnf && dd if=/dev/zero of=/tmp/nnf/file.in bs=128 count=0 seek=$((1024 * 1024))
     fi
 
-    kind create cluster --wait 60s --image=kindest/node:v1.22.5 --config kind-config.yaml
+    kind create cluster --wait 60s --image=kindest/node:v1.25.2 --config $CONFIG
 
-    # TODO: Initialization should move to init.sh
-
-    # Use the kind-control-plane node for the SLCMs.  Remove its default taint
-    # and label it for our use.
-    kubectl taint node kind-control-plane node-role.kubernetes.io/master:NoSchedule-
-    kubectl label node kind-control-plane cray.nnf.manager=true
-    kubectl label node kind-control-plane cray.wlm.manager=true
-
-    # Taint the kind workers as rabbit nodes for the NLCMs, to keep any
-    # non-NLCM pods off of them.
-    NODES=$(kubectl get nodes --no-headers -o custom-columns=:metadata.name | grep -v control-plane | paste -d" " -s -)
-    # shellcheck disable=2086
-    kubectl taint nodes $NODES cray.nnf.node=true:NoSchedule
-
-    # Label the kind-workers as rabbit nodes for the NLCMs.
-    for NODE in $(kubectl get nodes --no-headers | grep --invert-match "control-plane" | awk '{print $1}'); do
-        kubectl label node "$NODE" cray.nnf.node=true
-        kubectl label node "$NODE" cray.nnf.x-name="$NODE"
-    done
-
-    #Required for webhooks
-    install_cert_manager
-
+    # Required for webhooks
+    install_cert_manager 
 fi
 
 if [[ "$CMD" == destroy ]]; then


### PR DESCRIPTION
- Update Kubernetes version to v1.25.2, matching LLNL
- Convert to using kubeadm configurations for worker nodes: that is taints & labels
  - Stop trying to place resources on the control-plane, use a dedicated worker node for WLM & NNF Managers (SLCs) as this is more realistic
  - Only write the kind-config.yaml if it's **not** present so that you can modify the config. This means ***YOU MUST DELETE YOUR CACHED kind-config.yaml TO PICK UP THESE CHANGES***
- Remove x-name junk

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>