### PR TITLE
Convert the base64 decode argument to long-form format '--decode'

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,14 +235,14 @@ func (cmd *InstallCmd) Run(ctx *Context) error {
 			fmt.Println("  Secret:", d.ServiceAccount.Name+"/"+d.ServiceAccount.Namespace)
 
 			fmt.Printf("  Token...")
-			token, err = exec.Command("bash", "-c", fmt.Sprintf("kubectl get secret %s -n %s -o json | jq -Mr '.data.token' | base64 -D", d.ServiceAccount.Name, d.ServiceAccount.Namespace)).Output()
+			token, err = exec.Command("bash", "-c", fmt.Sprintf("kubectl get secret %s -n %s -o json | jq -Mr '.data.token' | base64 --decode", d.ServiceAccount.Name, d.ServiceAccount.Namespace)).Output()
 			if err != nil {
 				return err
 			}
 			fmt.Println("Loaded REDACTED")
 
 			fmt.Printf("  Cert...")
-			cert, err = exec.Command("bash", "-c", fmt.Sprintf("kubectl get secret %s -n %s -o json | jq -Mr '.data.\"ca.crt\"' | base64 -D", d.ServiceAccount.Name, d.ServiceAccount.Namespace)).Output()
+			cert, err = exec.Command("bash", "-c", fmt.Sprintf("kubectl get secret %s -n %s -o json | jq -Mr '.data.\"ca.crt\"' | base64 --decode", d.ServiceAccount.Name, d.ServiceAccount.Namespace)).Output()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
As Brian mentioned in Slack, the base64 '-D' option is a BSD/Darwin-specific option that would work on our MacBooks but is not defined for Linux, which uses lowercase '-d'. Turns out the long-form format, `--decode`, is supported by both and is therefore preferred

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>