### PR TITLE
Always use new kind config, update systems.yaml

### DIFF
--- a/config/systems.yaml
+++ b/config/systems.yaml
@@ -4,10 +4,10 @@ systems:
   aliases: [kind-kind]
   overlays: [kind, overlays/kind]
   master: kind-control-plane
-  workers:
+  workers: [kind-worker]
   rabbits:
-    kind-worker: {0: compute-01, 1: compute-02, 6: compute-03}
-    kind-worker2: {4: compute-04}
+    kind-worker2: {0: compute-01, 1: compute-02, 6: compute-03}
+    kind-worker3: {4: compute-04}
 - name: craystack-default
   aliases: [craystack]
   overlays: [craystack]

--- a/kind.sh
+++ b/kind.sh
@@ -30,11 +30,8 @@ fi
 if [[ "$CMD" == "create" ]]; then
     CONFIG=kind-config.yaml
 
-    # Only write the config if it's not present; this allows customization 
-    if ! [[ -f "$CONFIG" ]]; then
-
-      # Rabbit & WLM System Local Controllers (SLC)
-      SLCCONFIG=$(cat << EOF
+    # Rabbit & WLM System Local Controllers (SLC)
+    SLCCONFIG=$(cat << EOF
 
   kubeadmConfigPatches:
   - |
@@ -45,8 +42,8 @@ if [[ "$CMD" == "create" ]]; then
 EOF
 )
 
-      # Rabbit taints/labels, plus some host mounts for data movement
-      RABBITCONFIG=$(cat << EOF
+    # Rabbit taints/labels, plus some host mounts for data movement
+    RABBITCONFIG=$(cat << EOF
 
   extraMounts:
     - hostPath: /tmp/nnf
@@ -65,7 +62,7 @@ EOF
 EOF
 )
 
-      cat > $CONFIG <<EOF
+    cat > $CONFIG <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
@@ -76,8 +73,6 @@ nodes:
 - role: worker $RABBITCONFIG
 - role: worker $RABBITCONFIG
 EOF
-
-    fi
 
     # create a file for data movement
     if [ ! -f /tmp/nnf/file.in ]; then


### PR DESCRIPTION
Always create the kind-config; even if it already exists - this ensures that the systems.yaml matches the config.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>