### PR TITLE
Flag a failed test system as 'needing triage' and prevent tests from …

### DIFF
--- a/test/internal/system.go
+++ b/test/internal/system.go
@@ -29,12 +29,12 @@ import (
 )
 
 const (
-	TirageNamespaceName = "nnf-system-needs-triage"
+	TriageNamespaceName = "nnf-system-needs-triage"
 )
 
 func IsSystemInNeedOfTriage(ctx context.Context, k8sClient client.Client) bool {
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TirageNamespaceName}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TriageNamespaceName}}
 	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
 
 	return !errors.IsNotFound(err)
@@ -42,7 +42,7 @@ func IsSystemInNeedOfTriage(ctx context.Context, k8sClient client.Client) bool {
 
 func SetSystemInNeedOfTriage(ctx context.Context, k8sClient client.Client) error {
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TirageNamespaceName}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TriageNamespaceName}}
 	if err := k8sClient.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}

--- a/test/internal/system.go
+++ b/test/internal/system.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	TirageNamespaceName = "nnf-system-needs-triage"
+)
+
+func IsSystemInNeedOfTriage(ctx context.Context, k8sClient client.Client) bool {
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TirageNamespaceName}}
+	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+
+	return !errors.IsNotFound(err)
+}
+
+func SetSystemInNeedOfTriage(ctx context.Context, k8sClient client.Client) error {
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TirageNamespaceName}}
+	if err := k8sClient.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 
 	// Check if the system is currently in need of tirage and prevent test execution if so
 	if IsSystemInNeedOfTriage(ctx, k8sClient) {
-		AbortSuite(fmt.Sprintf("System requires triage. Delete the '%s' namespace when finished", TirageNamespaceName))
+		AbortSuite(fmt.Sprintf("System requires triage. Delete the '%s' namespace when finished", TriageNamespaceName))
 	}
 })
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -21,10 +21,13 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/NearNodeFlash/nnf-deploy/test/internal"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -88,9 +91,20 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	// Check if the system is currently in need of tirage and prevent test execution if so
+	if IsSystemInNeedOfTriage(ctx, k8sClient) {
+		AbortSuite(fmt.Sprintf("System requires triage. Delete the '%s' namespace when finished", TirageNamespaceName))
+	}
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
+
+	// Mark the system as needing triage if any spec failed
+	if ctx.SpecReport().Failed() {
+		SetSystemInNeedOfTriage(ctx, k8sClient)
+	}
+
 	cancel()
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Flag a failed test system as 'needing triage' and prevent tests from running if the tirage flag is set