### PR TITLE
Nnf test system reservation

### DIFF
--- a/test/internal/system_test.go
+++ b/test/internal/system_test.go
@@ -48,7 +48,7 @@ func TestAuthorizedDevelopers(t *testing.T) {
 			},
 		}
 
-		reserved, developer, err := isReserved(&namespaces)
+		reserved, _, err := isReserved(&namespaces)
 		if err != nil {
 			t.Errorf("error %t", err)
 		}
@@ -56,8 +56,6 @@ func TestAuthorizedDevelopers(t *testing.T) {
 		if !reserved {
 			t.Errorf("reservation '%s' not found", name)
 		}
-
-		t.Logf("reservation '%s' found for '%s'", name, developer)
 	}
 
 }

--- a/test/internal/system_test.go
+++ b/test/internal/system_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAuthorizedDevelopers(t *testing.T) {
+
+	names := []string{
+		"bryce",
+		"bryced",
+		"brycedevcich",
+		"bryce-d",
+		"bryce-devcich",
+		"bryce-is-a-pretty-cool-dude-if-you-get-to-know-him",
+	}
+
+	for _, name := range names {
+		namespaces := corev1.NamespaceList{
+			Items: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+				},
+			},
+		}
+
+		reserved, developer, err := isReserved(&namespaces)
+		if err != nil {
+			t.Errorf("error %t", err)
+		}
+
+		if !reserved {
+			t.Errorf("reservation '%s' not found", name)
+		}
+
+		t.Logf("reservation '%s' found for '%s'", name, developer)
+	}
+
+}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -21,6 +21,7 @@ package test
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"testing"
 
@@ -45,6 +46,8 @@ import (
 )
 
 var (
+	ignoreReservation bool
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -52,6 +55,10 @@ var (
 
 	k8sClient client.Client
 )
+
+func init() {
+	flag.BoolVar(&ignoreReservation, "ignore-reservation", false, "Ignore any reservations on the system that might prevent test execution")
+}
 
 func TestEverything(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -97,12 +104,17 @@ var _ = BeforeSuite(func() {
 		AbortSuite(fmt.Sprintf("System requires triage. Delete the '%s' namespace when finished", TriageNamespaceName))
 	}
 
-	reserved, developer, err := IsSystemReserved(ctx, k8sClient)
-	Expect(err).NotTo(HaveOccurred())
+	// Check if the system is being reserved by a developer
+	if !ignoreReservation {
+		By("Checking for system reservation")
+		reserved, developer, err := IsSystemReserved(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
 
-	if reserved {
-		AbortSuite(fmt.Sprintf("System is current reserved by '%s'", developer))
+		if reserved {
+			AbortSuite(fmt.Sprintf("System is current reserved by '%s'", developer))
+		}
 	}
+
 })
 
 var _ = AfterSuite(func(ctx SpecContext) {

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -96,6 +96,13 @@ var _ = BeforeSuite(func() {
 	if IsSystemInNeedOfTriage(ctx, k8sClient) {
 		AbortSuite(fmt.Sprintf("System requires triage. Delete the '%s' namespace when finished", TriageNamespaceName))
 	}
+
+	reserved, developer, err := IsSystemReserved(ctx, k8sClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	if reserved {
+		AbortSuite(fmt.Sprintf("System is current reserved by '%s'", developer))
+	}
 })
 
 var _ = AfterSuite(func(ctx SpecContext) {


### PR DESCRIPTION
Adds a reservation mechanism to ensure no system test runs on a currently reserved system. 

To reserve a system, create a namespace in your name. The regexp is defined to take first name and last name combinations like "nate", "natet", "nate-thornton", "nate-with-any-annotation". The important thing is it _must_ start with your name; "hey-this-is-nate" would not qualify.

To run the test suite against a reserved system, use the `--ignore-reservation` flag.

If a system is reserved (as it current is as of this writing), you'll see the test suite abort with a message like
`[ABORTED] System is current reserved by 'Matt Richerson'`