### PR TITLE
RABSW-1150: Use new daemon ServiceAccounts

### DIFF
--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -4,7 +4,7 @@ daemons:
     repository: nnf-dm
     path: daemons/compute/server
     serviceAccount:
-      name: nnf-dm-controller-manager
+      name: nnf-dm-daemon
       namespace: nnf-dm-system
   - name: client-mount
     bin: clientmount
@@ -12,5 +12,5 @@ daemons:
     path: mount-daemon
     skipNnfNodeName: true
     serviceAccount:
-      name: dws-operator-controller-manager
+      name: dws-operator-clientmount
       namespace: dws-operator-system


### PR DESCRIPTION
The clientmount and nnf-dm daemons have their own ServiceAccounts now. Use the secrets from these ServiceAccounts for the token and cert files.