### PR TITLE
RABSW-1025: Deploy Cert and Token for nnf fencing agent

### DIFF
--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -1,4 +1,9 @@
 daemons:
+  - name: nnf-fence
+    repository: nnf-sos
+    serviceAccount:
+      name: nnf-fencing-agent
+      namespace: nnf-system
   - name: nnf-data-movement
     bin: nnf-dm
     repository: nnf-dm


### PR DESCRIPTION
The HA cluster requires a fencing agent that can communicate with kubernetes. Copy the cert and token to the compute nodes during the "nnf-deploy install" step.