### PR TITLE
Add verification to System Configuration (systems.yaml)

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -1,10 +1,9 @@
-name: Unit Tests
-
+name: NNF int-test
 on: [push]
 
 jobs:
-  config-unit-test:
-    runs-on: ubuntu-latest
+  int-test:
+    runs-on: self-hosted
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -24,5 +23,5 @@ jobs:
       run: >
         GINKGO_CLI_VER=$(grep "github.com/onsi/ginkgo" go.mod | awk '{print $2}')
         bash -c 'go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_CLI_VER'
-    - name: Run Unit Tests
-      run: type ginkgo && ginkgo version && ginkgo run -p --vv ./config/...
+    - name: Run int-test on Self-Hosted System
+      run: type ginkgo && ginkgo version && ginkgo run -p --vv ./test/...

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: NNF Test
 on: [push]
 
 jobs:
-  test:
+  int-test:
     runs-on: self-hosted
     steps:
     - name: Checkout
@@ -24,4 +24,28 @@ jobs:
       run: >
         GINKGO_CLI_VER=$(grep "github.com/onsi/ginkgo" go.mod | awk '{print $2}')
         bash -c 'go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_CLI_VER'
-    - run: type ginkgo && ginkgo version && ginkgo run -p --vv ./test/...
+    - name: Run int-test on Self-Hosted System
+      run: type ginkgo && ginkgo version && ginkgo run -p --vv ./test/...
+  config-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+    - name: Setup Ginkgo
+      run: >
+        GINKGO_MOD=$(grep "github.com/onsi/ginkgo" go.mod | awk '{print $1 "@" $2}')
+        GOMEGA_VER=$(grep "github.com/onsi/gomega" go.mod | awk '{print $2}')
+        bash -c 'echo Using $GINKGO_MOD and gomega $GOMEGA_VER && go get $GINKGO_MOD && go get github.com/onsi/gomega@$GOMEGA_VER'
+    - name: Setup Ginkgo CLI
+      run: >
+        GINKGO_CLI_VER=$(grep "github.com/onsi/ginkgo" go.mod | awk '{print $2}')
+        bash -c 'go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_CLI_VER'
+    - name: Run Unit Tests
+      run: type ginkgo && ginkgo version && ginkgo run -p --vv ./config/...

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
+.PHONY: test
+
+test:
+	ginkgo run -p --vv ./config/...
+
 int-test:
 	ginkgo run -p --vv ./test/...

--- a/config/config.go
+++ b/config/config.go
@@ -23,9 +23,18 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v2"
 )
+
+const (
+	DefaultSysCfgPath    = "config/systems.yaml"
+	DefaultRepoCfgPath   = "config/repositories.yaml"
+	DefaultDaemonCfgPath = "config/daemons.yaml"
+)
+
+var sysCfgPath string
 
 type System struct {
 	Name     string                    `yaml:"name"`
@@ -39,14 +48,9 @@ type SystemConfigFile struct {
 	Systems []System `yaml:"systems"`
 }
 
-func FindSystem(name string) (*System, error) {
-	configFile, err := os.ReadFile("config/systems.yaml")
+func FindSystem(name, configPath string) (*System, error) {
+	config, err := ReadConfig(configPath)
 	if err != nil {
-		return nil, err
-	}
-
-	config := new(SystemConfigFile)
-	if err := yaml.Unmarshal(configFile, config); err != nil {
 		return nil, err
 	}
 
@@ -64,6 +68,108 @@ func FindSystem(name string) (*System, error) {
 	return nil, fmt.Errorf("System '%s' Not Found", name)
 }
 
+func ReadConfig(path string) (*SystemConfigFile, error) {
+	configFile, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read system config: %v", err)
+	}
+
+	config := new(SystemConfigFile)
+	if err := yaml.UnmarshalStrict(configFile, config); err != nil {
+		return nil, fmt.Errorf("invalid system config yaml: %v", err)
+	}
+
+	sysCfgPath = path
+
+	if err := config.Verify(); err != nil {
+		return nil, fmt.Errorf("invalid system config: %v", err)
+	}
+
+	return config, nil
+}
+
+func (config *SystemConfigFile) Verify() error {
+	knownNames := make(map[string]bool)
+	knownAlias := make(map[string]bool)
+
+	for _, system := range config.Systems {
+
+		// Make sure system names only appear once
+		if _, found := knownNames[system.Name]; found {
+			return fmt.Errorf("system name '%s' declared more than once in '%s'", system.Name, sysCfgPath)
+		}
+		knownNames[system.Name] = true
+
+		// Make sure alias only appear once
+		for _, alias := range system.Aliases {
+			if _, found := knownAlias[alias]; found {
+				return fmt.Errorf("alias '%s' declared more than once in '%s'", alias, sysCfgPath)
+			}
+			knownAlias[alias] = true
+		}
+
+		// Verify the individual components in the system (e.g. rabbits, computes)
+		if err := system.Verify(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (system *System) Verify() error {
+	knownAliases := make(map[string]bool)
+	knownOverlays := make(map[string]bool)
+	knownComputes := make(map[string]bool)
+	knownWorkers := make(map[string]bool)
+
+	if len(system.Rabbits) < 1 {
+		return fmt.Errorf("no rabbit nodes declared for system '%s' in '%s'", system.Name, sysCfgPath)
+	}
+
+	// Ensure computes are only listed once. `yaml.UnmarshalStrict` will catch duplicate rabbit names since it's a map.
+	for _, computes := range system.Rabbits {
+		for _, compute := range computes {
+			if _, found := knownComputes[compute]; found {
+				return fmt.Errorf("compute node '%s' declared more than once for system '%s' in '%s'", compute, system.Name, sysCfgPath)
+			}
+			knownComputes[compute] = true
+		}
+	}
+
+	// Aliases
+	for _, alias := range system.Aliases {
+		if _, found := knownAliases[alias]; found {
+			return fmt.Errorf("alias '%s' declared more than once for system '%s' in '%s'", alias, system.Name, sysCfgPath)
+		}
+		knownAliases[alias] = true
+	}
+
+	// Overlays
+	if len(system.Overlays) < 1 {
+		return fmt.Errorf("no overlays declared for system '%s' in '%s'", system.Name, sysCfgPath)
+	}
+	for _, overlay := range system.Overlays {
+		if _, found := knownOverlays[overlay]; found {
+			return fmt.Errorf("overlay'%s' declared more than once for system '%s' in '%s'", overlay, system.Name, sysCfgPath)
+		}
+		knownOverlays[overlay] = true
+	}
+
+	// Workers
+	if len(system.Workers) < 1 {
+		return fmt.Errorf("no workers declared for system '%s' in '%s'", system.Name, sysCfgPath)
+	}
+	for _, worker := range system.Workers {
+		if _, found := knownWorkers[worker]; found {
+			return fmt.Errorf("worker node '%s' declared more than once for system '%s' in '%s'", worker, system.Name, sysCfgPath)
+		}
+		knownWorkers[worker] = true
+	}
+
+	return nil
+}
+
 type RepositoryConfigFile struct {
 	Repositories []Repository `yaml:"repositories"`
 }
@@ -77,16 +183,16 @@ type Repository struct {
 
 func FindRepository(module string) (*Repository, error) {
 
-	configFile, err := os.ReadFile("config/repositories.yaml")
+	configFile, err := os.ReadFile(DefaultRepoCfgPath)
 	if err != nil {
-		configFile, err = os.ReadFile("../config/repositories.yaml")
+		configFile, err = os.ReadFile(filepath.Join("..", DefaultRepoCfgPath))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	config := new(RepositoryConfigFile)
-	if err := yaml.Unmarshal(configFile, config); err != nil {
+	if err := yaml.UnmarshalStrict(configFile, config); err != nil {
 		return nil, err
 	}
 
@@ -117,13 +223,13 @@ type DaemonConfigFile struct {
 }
 
 func EnumerateDaemons(handleFn func(Daemon) error) error {
-	configFile, err := os.ReadFile("config/daemons.yaml")
+	configFile, err := os.ReadFile(DefaultDaemonCfgPath)
 	if err != nil {
 		return err
 	}
 
 	config := new(DaemonConfigFile)
-	if err := yaml.Unmarshal(configFile, config); err != nil {
+	if err := yaml.UnmarshalStrict(configFile, config); err != nil {
 		return err
 	}
 

--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,188 @@
+package config_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NearNodeFlash/nnf-deploy/config"
+)
+
+var _ = Describe("Config", func() {
+	var tempFile *os.File
+
+	BeforeEach(func() {
+		var err error
+		tempFile, err = os.CreateTemp("", "tmpsysconfig-")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.Remove(tempFile.Name())
+	})
+
+	createConfigFile := func(input string) {
+		_, err := tempFile.WriteString(input)
+		Expect(err).ToNot(HaveOccurred())
+		defer tempFile.Close()
+	}
+
+	Describe("Verifying Systems Configuration", func() {
+		When("multiple systems have the same name", func() {
+			var input = `
+systems:
+  - name: one
+    workers: [worker1]
+    overlays: [overlay1]
+    rabbits:
+      rabbit-node-1: {0: "compute-1"}
+  - name: one
+    workers: [worker2]
+    overlays: [overlay2]
+    rabbits:
+      rabbit-node-2: {0: "compute-2"}
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("multiple systems have the same alias", func() {
+			var input = `
+systems:
+  - name: one
+    aliases: [1]
+    workers: [worker1]
+    overlays: [overlay1]
+    rabbits:
+      rabbit-node-1: {0: "compute-1"}
+  - name: two
+    aliases: [1, 2]
+    workers: [worker2]
+    overlays: [overlay2]
+    rabbits:
+      rabbit-node-2: {0: "compute-2"}
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("A system has no aliases", func() {
+			var input = `
+systems:
+  - name: no-alias
+    overlays: [overlay2]
+    workers: [worker2]
+    rabbits:
+      rabbit-node-2: {0: "compute-2"}
+`
+			It("should not error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("A system has no workers", func() {
+			var input = `
+systems:
+  - name: no-workers
+    overlays: [overlay2]
+    rabbits:
+      rabbit-node-2: {0: "compute-2"}
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("A system has no overlays", func() {
+			var input = `
+systems:
+  - name: no-workers
+    workers: [worker2]
+    rabbits:
+      rabbit-node-2: {0: "compute-2"}
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("A system declares a rabbit node twice", func() {
+			var input = `
+systems:
+  - name: two-rabbits
+    workers: [worker2]
+    overlays: [overlay2]
+    rabbits:
+      rabbit-node-2: {0: "compute-node-2"}
+      rabbit-node-2: {0: "compute-node-3"}
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("A system has no rabbit nodes", func() {
+			var input = `
+systems:
+  - name: no-rabbits
+    workers: [worker2]
+    overlays: [overlay2]
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("A system declares a compute node twice", func() {
+			var input = `
+systems:
+  - name: two-computes
+    workers: [worker2, worker3]
+    overlays: [overlay2]
+    rabbits:
+      rabbit-node-2: {0: "compute-2"}
+      rabbit-node-3: {0: "compute-2"}
+`
+			It("should error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("A rabbit node has no compute nodes", func() {
+			var input = `
+systems:
+  - name: two-computes
+    workers: [worker2, worker3]
+    overlays: [overlay2]
+    rabbits:
+      rabbit-node-2: {}
+      rabbit-node-3: {}
+`
+			It("should not error", func() {
+				createConfigFile(input)
+				_, err := config.ReadConfig(tempFile.Name())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+	})
+})

--- a/config/systems.yaml
+++ b/config/systems.yaml
@@ -36,6 +36,6 @@ systems:
   - name: rabbit-htx-2
     aliases: [htx-2]
     overlays: [dp0, overlays/rabbit]
-    workers: [compute-node-5]
+    workers: [rabbit-compute-5]
     rabbits:
       rabbit-node-2: { 0: compute-node-4, 1: compute-node-5 }

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ replace (
 
 require (
 	github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8
-	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b
+	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230426150127-b7cba32758e5
 	github.com/NearNodeFlash/nnf-dm v0.0.0-20221110213934-14699bac1e45
-	github.com/NearNodeFlash/nnf-sos v0.0.0-20230411182150-1f061ae44ca5
+	github.com/NearNodeFlash/nnf-sos v0.0.0-20230428210046-53297ed0c2ce
 	github.com/alecthomas/kong v0.7.1
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.3
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d // indirect
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d h1:Fq4ev963g4VkQy5S2QTq4R1ZBw/e5Qpv1uMCg3QcWRE=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f h1:kJetY6ACr44dAKEbJkXCwDdbnqqx4KKx63cjXPCHktQ=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4=

--- a/main.go
+++ b/main.go
@@ -68,9 +68,6 @@ var cli struct {
 func main() {
 	ctx := kong.Parse(&cli)
 	err := ctx.Run(&Context{Debug: cli.Debug, DryRun: cli.DryRun})
-	if err != nil {
-		fmt.Printf("%v", err)
-	}
 	ctx.FatalIfErrorf(err)
 }
 
@@ -1030,7 +1027,7 @@ func loadSystem() (*config.System, error) {
 	}
 
 	fmt.Println("Retrieving System Config...")
-	system, err := config.FindSystem(ctx)
+	system, err := config.FindSystem(ctx, config.DefaultSysCfgPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Add checks for:
  * duplicate system names
  * duplicate aliases
  * missing overlays
  * missing workers
  * duplicate rabbit node names
  * duplicate compute node names (in a system)
* Add supporting functions to make system config eaiser to test
* Add unit tests for config.go
  * Add Makefile to run tests locally
  * Add GitHub workflow to run tests
* Fixed incorrectly named worker node for htx-2
* Fixed bug in main.go that prints error output twice

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
