### PR TITLE
Handle third-party services

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -54,3 +54,17 @@ buildConfiguration:
     - name: NNFMFU_VERSION
       value: 0.0.1
 
+thirdPartyServices:
+  # Other services that NNF requires to be available on the system.
+  # They will be installed in the order specified here.
+  - name: cert-manager
+    useRemoteF: true
+    url: https://github.com/jetstack/cert-manager/releases/download/v1.11.1/cert-manager.yaml
+    # The NNF services will dump errors at installation time if the
+    # cert-manager webhook isn't ready.
+    waitCmd: kubectl wait pod -n cert-manager --timeout=180s -l app.kubernetes.io/component=webhook --for jsonpath='{.status.phase}'=Running
+  - name: mpi-operator
+    useRemoteF: true
+    url: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.4.0/deploy/v2beta1/mpi-operator.yaml
+
+


### PR DESCRIPTION
Create a generic way to handle third-party services like cert-manager and mpi-operator.

Add a section to repositories.yaml to handle the third-party services.  Allow a "wait command" to be specified, so we can wait for the webhook on a service like cert-manager.