### PR TITLE
Improve main.go dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-all: build
+all: fmt vet nnf-deploy
 
-.PHONY: build
-build: fmt vet
+nnf-deploy: main.go
 	go build
 
 .PHONY: fmt


### PR DESCRIPTION
Allow make to determine whether "nnf-deploy" is out of date with "main.go".