### PR TITLE
Build daemons using their makefiles

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -238,6 +238,7 @@ func GetThirdPartyServices(configPath string) ([]ThirdPartyService, error) {
 type Daemon struct {
 	Name            string `yaml:"name"`
 	Bin             string `yaml:"bin"`
+	BuildCmd        string `yaml:"buildCmd"`
 	Repository      string `yaml:"repository"`
 	Path            string `yaml:"path"`
 	SkipNnfNodeName bool   `yaml:"skipNnfNodeName"`

--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -6,16 +6,18 @@ daemons:
       namespace: nnf-system
   - name: nnf-data-movement
     bin: nnf-dm
+    buildCmd: make build-daemon
+    path: bin/
     repository: nnf-dm
-    path: daemons/compute/server
     serviceAccount:
       name: nnf-dm-daemon
       namespace: nnf-dm-system
     extraArgs: "--kubernetes-qps 50 --kubernetes-burst 100"
   - name: client-mount
-    bin: clientmount
+    bin: clientmountd
+    buildCmd: make build-daemon
+    path: bin/
     repository: dws
-    path: mount-daemon
     skipNnfNodeName: true
     serviceAccount:
       name: dws-operator-clientmount

--- a/test/int_test.go
+++ b/test/int_test.go
@@ -86,11 +86,11 @@ var tests = []*T{
 	MakeTest("GFS2 with MPI Containers",
 		"#DW jobdw type=gfs2 name=gfs2-with-containers-mpi capacity=100GB",
 		"#DW container name=gfs2-with-containers-mpi profile=example-mpi DW_JOB_foo_local_storage=gfs2-with-containers-mpi").
-		WithPermissions(1050, 2050).WithLabels("mpi"),
+		WithPermissions(1050, 1051).WithLabels("mpi"),
 	MakeTest("Lustre with MPI Containers",
 		"#DW jobdw type=lustre name=lustre-with-containers-mpi capacity=100GB",
 		"#DW container name=lustre-with-containers-mpi profile=example-mpi DW_JOB_foo_local_storage=lustre-with-containers-mpi").
-		WithPermissions(2050, 2051).WithLabels("mpi"),
+		WithPermissions(1050, 1051).WithLabels("mpi"),
 
 	// Containers - Non-MPI
 	MakeTest("GFS2 with Containers",
@@ -115,14 +115,14 @@ var tests = []*T{
 		"#DW persistentdw name=containers-persistent-storage",
 		"#DW container name=gfs2-lustre-with-containers profile=example-success DW_JOB_foo_local_storage=containers-local-storage DW_PERSISTENT_foo_persistent_storage=containers-persistent-storage").
 		WithPersistentLustre("containers-persistent-storage").
-		WithPermissions(1050, 2050).
+		WithPermissions(1050, 1051).
 		Pending(),
 	MakeTest("GFS2 and Lustre with Containers MPI",
 		"#DW jobdw name=containers-local-storage-mpi type=gfs2 capacity=100GB",
 		"#DW persistentdw name=containers-persistent-storage-mpi",
 		"#DW container name=gfs2-lustre-with-containers-mpi profile=example-mpi DW_JOB_foo_local_storage=containers-local-storage-mpi DW_PERSISTENT_foo_persistent_storage=containers-persistent-storage-mpi").
 		WithPersistentLustre("containers-persistent-storage-mpi").
-		WithPermissions(1050, 2050).
+		WithPermissions(1050, 1051).
 		Pending(),
 }
 


### PR DESCRIPTION
**Note**: The existing clientmount services on compute nodes will need to be removed. See below.

The nnf-dm and client-mount daemons were being built manually in nnf-deploy rather than making use of their Makefiles. This was causing the versions to sit at 0.0.0 rather than the built in versioning. provided by the Makefiles.

In order to support this change, the client-mount service had to be renamed to clientmountd in dws. The binary built by the Makefile and the RPMs is named clientmountd, so nnf-deply looks for an clientmountd.service file - which wouldn't exist without the rename.

Any compute node running the old version will need to remove the service before the renamed service will work properly.

At LLNL, this should not be an issue since they are already using the clientmountd binary, but they are writing their own service file.