### PR TITLE
Reduce the size of the audit log summary

### DIFF
--- a/config/audit-policy.yaml
+++ b/config/audit-policy.yaml
@@ -11,7 +11,7 @@
 # $ jq -M . kube-apiserver-audit.log | less
 #
 # Dump a quick-to-digest summary of the log events:
-# $ jq -M '[.auditID,.verb,.requestURI,.user.username,.objectRef.name,.responseStatus.code,.stageTimestamp]' kube-apiserver-audit.log | less
+# $ jq -M '[.auditID,.verb,.requestURI,.user.username,.responseStatus.code,.stageTimestamp]' kube-apiserver-audit.log | less
 #
 # Extract a specific event record from the log:
 # $ jq -M '. | select(.auditID=="d1053ee5-0734-4b40-815f-3f6831f82bac")' kube-apiserver-audit.log | less


### PR DESCRIPTION
The .objectRef.name is already printed with the .requestURI.