### PR TITLE
Requirements for Prometheus

### DIFF
--- a/config/service-monitor-selector.yaml
+++ b/config/service-monitor-selector.yaml
@@ -1,0 +1,24 @@
+# An override for the prometheus-community/kube-prometheus-stack helm chart.
+#
+# This adds a selector to the Prometheus resource so it can find the
+# ServiceMonitor resources that our repos are creating.  Each submodule defines
+# its ServiceMonitor resource in `config/prometheus/monitor.yaml`.
+#
+# helm repo add prometheus-community \
+#    https://prometheus-community.github.io/helm-charts
+# helm repo update
+# helm search repo prometheus-community | grep kube-prometheus-stack
+# helm show values prometheus-community/kube-prometheus-stack \
+#    --version $CHART_VER > kube-prometheus-stack.yaml
+#
+# helm install $INSTANCE_NAME prometheus-community/kube-prometheus-stack \
+#    --version $CHART_VER --create-namespace --namespace monitoring \
+#    --values $THIS_OVERRIDE_FILE
+# 
+
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelector:
+      matchLabels:
+        prometheus-app: rabbit-nnf
+

--- a/deploy-prometheus.sh
+++ b/deploy-prometheus.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Prometheus on an existing cluster.
+
+CMD=$1
+
+INSTANCE_NAME=rabbit
+LOCAL_NAME=prometheus-community
+NAMESPACE=monitoring
+CHART_VER=52.1.0
+
+set -e
+
+# We want helm v3.
+helm version | grep -qE Version:.v3
+
+if [[ $CMD == 'deploy' ]]; then
+
+    helm repo add $LOCAL_NAME https://prometheus-community.github.io/helm-charts
+    helm repo update $LOCAL_NAME
+
+    helm install $INSTANCE_NAME prometheus-community/kube-prometheus-stack \
+      --version $CHART_VER --create-namespace --namespace $NAMESPACE \
+      --values config/service-monitor-selector.yaml
+
+    helm list -n $NAMESPACE
+fi
+
+if [[ $CMD == 'undeploy' ]]; then
+    # This does not uninstall the CRDs.
+    helm uninstall $INSTANCE_NAME -n $NAMESPACE
+fi
+
+exit 0


### PR DESCRIPTION
Introduce a deploy-prometheus.sh script that can install the prometheus-community/kube-prometheus-stack helm chart.  Include a file that overrides the ServiceMonitor selector in the chart's values,yaml.  This selector inserts a label that is common across the ServiceMonitor resources in the DWS and NNF repos.