### PR TITLE
Readme: fix build instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ nnf-deploy is a golang executable capable of building components of the Rabbit s
 
 ### Build
 
-Build using: `go build`
+Build using: `make`
 
 Prior to running, ensure correct NNF systems are loaded in [./config/systems.yaml](./config/systems.yaml) and correct ghcr repositories are defined in [./config/repositories.yaml](./config/repositories.yaml)
 


### PR DESCRIPTION
Problem: Readme.md indicates that 'go build' in the root directory will build nnf-deploy, but this is not the case since 3c49e3c.

Fix the instructions to say that running 'make' is the proper way to build the nnf-deploy executable.