### PR TITLE
Use clientmountd in nnf-sos

### DIFF
--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -17,8 +17,8 @@ daemons:
     bin: clientmountd
     buildCmd: make build-daemon
     path: bin/
-    repository: dws
+    repository: nnf-sos
     skipNnfNodeName: true
     serviceAccount:
-      name: dws-clientmount
-      namespace: dws-system
+      name: nnf-clientmount
+      namespace: nnf-system


### PR DESCRIPTION
clientmountd moved from dws to nnf-sos. Update the daemons.conf file to point to the new repo and use the correct service account.