### PR TITLE
Add daemon env var support; tune daemon garbage collection, max procs, & HTTP2 health check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -253,7 +253,13 @@ type Daemon struct {
 		Name      string `yaml:"name"`
 		Namespace string `yaml:"namespace"`
 	} `yaml:"serviceAccount,omitempty"`
-	ExtraArgs string `yaml:"extraArgs,omitempty"`
+	ExtraArgs   string   `yaml:"extraArgs,omitempty"`
+	Environment []EnvVar `yaml:"env,omitempty"`
+}
+
+type EnvVar struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value,omitempty"`
 }
 
 type DaemonConfigFile struct {

--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -13,6 +13,15 @@ daemons:
       name: nnf-dm-daemon
       namespace: nnf-dm-system
     extraArgs: '--kubernetes-qps 50 --kubernetes-burst 100'
+    env:
+      - name: GOGC
+        value: "off"
+      - name: GOMEMLIMIT
+        value: "20MiB"
+      - name: GOMAXPROCS
+        value: 5
+      - name: HTTP2_PING_TIMEOUT_SECONDS
+        value: 60
   - name: client-mount
     bin: clientmountd
     buildCmd: make build-daemon
@@ -22,3 +31,12 @@ daemons:
     serviceAccount:
       name: nnf-clientmount
       namespace: nnf-system
+    env:
+      - name: GOGC
+        value: "off"
+      - name: GOMEMLIMIT
+        value: "20MiB"
+      - name: GOMAXPROCS
+        value: 5
+      - name: HTTP2_PING_TIMEOUT_SECONDS
+        value: 60


### PR DESCRIPTION
* Added Environment field to daemons to support environment variables in
  systemd overrides file
* Fixed an issue with line endings in the systemd overrides file that caused
  the first Environment field to be ignored
* Added tunings for both daemons

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
