### PR TITLE
Remove --nnf-node-name and --node-name from service files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -406,20 +406,21 @@ func (cmd *InstallCmd) Run(ctx *Context) error {
 					overrideContents += "ExecStart=\n"
 					overrideContents += "ExecStart=/usr/bin/" + d.Bin + " \\\n"
 					overrideContents += "  --kubernetes-service-host=" + k8sServerHost + " \\\n"
-					overrideContents += "  --kubernetes-service-port=" + k8sServerPort + " \\\n"
-					overrideContents += "  --node-name=" + compute + " "
-					if !d.SkipNnfNodeName {
-						overrideContents += "\\\n" + "  --nnf-node-name=" + rabbit + " "
-					}
+					overrideContents += "  --kubernetes-service-port=" + k8sServerPort
+
+					// optional command line arguments
 					if len(token) != 0 {
-						overrideContents += "\\\n" + "  --service-token-file=" + path.Join(serviceTokenPath, "service.token") + " "
+						overrideContents += " \\\n" + "  --service-token-file=" + path.Join(serviceTokenPath, "service.token")
 					}
 					if len(cert) != 0 {
-						overrideContents += "\\\n" + "  --service-cert-file=" + path.Join(certFilePath, "service.cert") + " "
+						overrideContents += " \\\n" + "  --service-cert-file=" + path.Join(certFilePath, "service.cert")
 					}
 					if len(d.ExtraArgs) > 0 {
-						overrideContents += "\\\n" + d.ExtraArgs + " "
+						overrideContents += " \\\n  " + d.ExtraArgs
 					}
+
+					// Add environment variables - there should not be a \ on the preceding line
+					// otherwise the first env var will not work
 					for _, e := range d.Environment {
 						overrideContents += "\n" + "Environment=" + e.Name + "=" + e.Value
 					}

--- a/config/config.go
+++ b/config/config.go
@@ -243,13 +243,12 @@ func GetThirdPartyServices(configPath string) ([]ThirdPartyService, error) {
 }
 
 type Daemon struct {
-	Name            string `yaml:"name"`
-	Bin             string `yaml:"bin"`
-	BuildCmd        string `yaml:"buildCmd"`
-	Repository      string `yaml:"repository"`
-	Path            string `yaml:"path"`
-	SkipNnfNodeName bool   `yaml:"skipNnfNodeName"`
-	ServiceAccount  struct {
+	Name           string `yaml:"name"`
+	Bin            string `yaml:"bin"`
+	BuildCmd       string `yaml:"buildCmd"`
+	Repository     string `yaml:"repository"`
+	Path           string `yaml:"path"`
+	ServiceAccount struct {
 		Name      string `yaml:"name"`
 		Namespace string `yaml:"namespace"`
 	} `yaml:"serviceAccount,omitempty"`

--- a/config/daemons.yaml
+++ b/config/daemons.yaml
@@ -27,7 +27,6 @@ daemons:
     buildCmd: make build-daemon
     path: bin/
     repository: nnf-sos
-    skipNnfNodeName: true
     serviceAccount:
       name: nnf-clientmount
       namespace: nnf-system


### PR DESCRIPTION
Both nnf-dm and clientmountd default to the system hostname if these options are not provided, so there is no need to keep providing them via the systemd service file. LLNL does not plan on setting these command line options to make configuration easier on their end - we should follow suit.

The formatting for the overrides file has been cleaned up a bit as well.