### PR TITLE
Use kubectl create for SystemConfiguration resource

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -976,7 +976,7 @@ func createSystemConfigFromSOS(ctx *Context, system *config.System, module strin
 
 	fmt.Println("Creating SystemConfiguration...")
 
-	cmd := exec.Command("kubectl", "apply", "-f", "../config/"+system.SystemConfiguration)
+	cmd := exec.Command("kubectl", "create", "-f", "../config/"+system.SystemConfiguration)
 	_, err := runCommand(ctx, cmd)
 	return err
 }


### PR DESCRIPTION
Use 'kubectl create' for this resource so that k8s does not create the "last-applied-configuration" annotation.  This resource is not being updated by any controller, and the admins can be taught to update it with 'kubectl replace' so that annotation is never needed.

This resource can be quite large on a big system and the "last-applied-configuration" annotation that is created by 'kubectl apply' can exceed the allowed size of an annotation.