### PR TITLE
README: fix broken path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,7 +152,7 @@ Kind clusters are built and deployed using locally compiled images. The followin
 - Deploy those images onto the Kind cluster nodes
 
 ```bash
-./kind.sh reset
+./tools/kind.sh reset
 ./nnf-deploy make docker-build
 ./nnf-deploy make kind-push
 ./nnf-deploy deploy


### PR DESCRIPTION
Problem: the `kind.sh` script was moved to the `tools` subdirectory but the path was not updated in the README.

Fix the path.