### PR TITLE
Turn on ArgoCD via helm for nnf-deploy init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 nnf-deploy
 
 kind-config.yaml
+overlay-*.yaml
 
 vendor/
 

--- a/Readme.md
+++ b/Readme.md
@@ -87,7 +87,6 @@ On a Mac, install helm with `brew install helm`.
 
 ```bash
 helm repo add argo https://argoproj.github.io/argo-helm
-helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -167,3 +167,16 @@ proper certs and tokens. Systemd files are used to manage and start the daemons.
 ./nnf-deploy install
 ```
 
+## ArgoCD Helm Chart
+
+To install the ArgoCD helm chart, run the following helm commands prior to
+running `tools/kind.sh` or `nnf-deploy init`.
+
+On a Mac, install helm with `brew install helm`.
+
+```bash
+helm repo add argo https://argoproj.github.io/argo-helm
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+```
+

--- a/Readme.md
+++ b/Readme.md
@@ -78,6 +78,19 @@ Commands:
 Run "nnf-deploy <command> --help" for more information on a command.
 ```
 
+## ArgoCD Helm Chart
+
+To install the ArgoCD helm chart, run the following helm commands prior to
+running `tools/kind.sh` or `nnf-deploy init`.
+
+On a Mac, install helm with `brew install helm`.
+
+```bash
+helm repo add argo https://argoproj.github.io/argo-helm
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+```
+
 ## Init
 
 The `init` subcommand applies the proper labels and taints to the cluster nodes. It also installs
@@ -165,18 +178,5 @@ proper certs and tokens. Systemd files are used to manage and start the daemons.
 
 ```bash
 ./nnf-deploy install
-```
-
-## ArgoCD Helm Chart
-
-To install the ArgoCD helm chart, run the following helm commands prior to
-running `tools/kind.sh` or `nnf-deploy init`.
-
-On a Mac, install helm with `brew install helm`.
-
-```bash
-helm repo add argo https://argoproj.github.io/argo-helm
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
 ```
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -523,7 +523,7 @@ func installThirdPartyServices(ctx *Context) error {
 	for idx := range thirdPartyServices {
 		svc := thirdPartyServices[idx]
 		if svc.UseRemoteF {
-			fmt.Printf("Installing %s...\n", svc.Name)
+			fmt.Printf("Installing from remote %s...\n", svc.Name)
 			if err := runKubectlApplyF(ctx, svc.Url); err != nil {
 				return err
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -522,12 +522,20 @@ func installThirdPartyServices(ctx *Context) error {
 
 	for idx := range thirdPartyServices {
 		svc := thirdPartyServices[idx]
-		if !svc.UseRemoteF {
+		if svc.UseRemoteF {
+			fmt.Printf("Installing %s...\n", svc.Name)
+			if err := runKubectlApplyF(ctx, svc.Url); err != nil {
+				return err
+			}
+		} else if svc.UseHelm {
+			fmt.Printf("Installing %s...\n", svc.Name)
+			cmd := exec.Command("bash", "-c", svc.HelmCmd)
+			_, err = runCommand(ctx, cmd)
+			if err != nil {
+				return err
+			}
+		} else {
 			continue
-		}
-		fmt.Printf("Installing %s...\n", svc.Name)
-		if err := runKubectlApplyF(ctx, svc.Url); err != nil {
-			return err
 		}
 		if len(svc.WaitCmd) > 0 {
 			fmt.Println("  waiting for it to be ready...")

--- a/config/config.go
+++ b/config/config.go
@@ -246,7 +246,6 @@ func FindRepository(configPath string, module string) (*Repository, *BuildConfig
 			for idx := range config.Repositories {
 				if config.Repositories[idx].Name == svc.Name {
 					config.Repositories[idx].UseRemoteK = svc.UseRemoteK
-
 				}
 			}
 		}

--- a/config/helm-values/argocd.yaml
+++ b/config/helm-values/argocd.yaml
@@ -1,0 +1,28 @@
+---
+global:
+  image:
+    tag: "v2.6.6"
+
+server:
+  extraArgs:
+    # Prevent argocd from generating self-cert and redirect http to https.
+    - --insecure
+    # "Instead, should use ingress and terminate https on the ingress level,
+    # then route plain http to argocd."
+
+configs:
+  cm:
+    resource.customizations.health.argoproj.io_Application: |
+      hs = {}
+      hs.status = "Progressing"
+      hs.message = ""
+      if obj.status ~= nil then
+        if obj.status.health ~= nil then
+          hs.status = obj.status.health.status
+          if obj.status.health.message ~= nil then
+            hs.message = obj.status.health.message
+          end
+        end
+      end
+      return hs
+

--- a/config/overlay-legacy.yaml-template
+++ b/config/overlay-legacy.yaml-template
@@ -1,0 +1,21 @@
+# Revert `nnf-deploy init` to legacy behavior:
+#   $ cp config/overlay-legacy.yaml-template overlay-legacy.yaml
+#
+# Effects:
+#   - Do not install helm.
+#   - Install cert-manager, mpi-operator, lustre-csi-driver, and
+#     lustre-fs-operator.
+#
+repositories:
+  - name: lustre-csi-driver
+    useRemoteK: true
+  - name: lustre-fs-operator
+    useRemoteK: true
+
+thirdPartyServices:
+  - name: cert-manager
+    useRemoteF: true
+  - name: mpi-operator
+    useRemoteF: true
+  - name: argocd
+    useHelm: false

--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -31,14 +31,14 @@ repositories:
     overlays: [overlays/rabbit, overlays/kind]
     development: https://ghcr.io/hewlettpackard/lustre-csi-driver
     master: https://ghcr.io/hewlettpackard/lustre-csi-driver
-    useRemoteK: true
+    useRemoteK: false
     remoteReference:
       build: master
       url: https://github.com/HewlettPackard/lustre-csi-driver.git/deploy/kubernetes/%s/?ref=%s
   - name: lustre-fs-operator
     development: https://ghcr.io/nearnodeflash/lustre-fs-operator
     master: https://ghcr.io/nearnodeflash/lustre-fs-operator
-    useRemoteK: true
+    useRemoteK: false
     remoteReference:
       build: master
       url: https://github.com/NearNodeFlash/lustre-fs-operator.git/config/default/?ref=%s
@@ -58,11 +58,16 @@ thirdPartyServices:
   # Other services that NNF requires to be available on the system.
   # They will be installed in the order specified here.
   - name: cert-manager
-    useRemoteF: true
+    useRemoteF: false
     url: https://github.com/jetstack/cert-manager/releases/download/v1.13.1/cert-manager.yaml
     # The NNF services will dump errors at installation time if the
     # cert-manager webhook isn't ready.
     waitCmd: kubectl wait deploy -n cert-manager --timeout=180s cert-manager-webhook --for jsonpath='{.status.availableReplicas}=1'
   - name: mpi-operator
-    useRemoteF: true
+    useRemoteF: false
     url: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.4.0/deploy/v2beta1/mpi-operator.yaml
+  - name: argocd
+    useHelm: true
+    helmCmd: helm install argocd -n argocd --create-namespace argo/argo-cd --version 3.35.4 -f config/helm-values/argocd.yaml
+    waitCmd: kubectl wait deploy -n argocd --timeout=180s argocd-server --for jsonpath='{.status.availableReplicas}=1'
+


### PR DESCRIPTION
Use helm to install ArgoCD.  Do not install cert-manager, mpi-operator, lustre-csi-driver, or lustre-fs-operator because those should be handled by ArgoCD.

Create an overlay file for the config/repositories.yaml file, to revert it back to its legacy pre-helm, pre-argocd behavior if desired.  To enable the overlay, it must be copied into the root of the repo and named 'overlay-legacy.yaml'.