### PR TITLE
Collect separate manifests for hardware vs KIND

### DIFF
--- a/.github/workflows/handle_release_tag.yaml
+++ b/.github/workflows/handle_release_tag.yaml
@@ -22,11 +22,13 @@ jobs:
     - name: Submodule status
       run: git submodule status
     - name: Collect manifests
-      run: tools/collect-manifests.sh -d ~+/release-manifests -t ~+/manifests.tar
+      run: make manifests
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         #prerelease: true
         generate_release_notes: true
-        files: manifests.tar
+        files: |
+            manifests.tar
+            manifests-kind.tar
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ kind-config.yaml
 vendor/
 
 release-manifests/
+release-manifests-kind/
 manifests.tar
+manifests-kind.tar
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ test:
 
 .PHONY: manifests
 manifests:
-	tools/collect-manifests.sh -d ~+/release-manifests -t ~+/manifests.tar
+	tools/collect-manifests.sh -s kind -d ~+/release-manifests-kind -t ~+/manifests-kind.tar
+	tools/collect-manifests.sh -s rabbit -d ~+/release-manifests -t ~+/manifests.tar
 
 .PHONY: clean-manifests
 clean-manifests:
+	rm -rf ~+/release-manifests-kind ~+/manifests-kind.tar
 	rm -rf ~+/release-manifests ~+/manifests.tar
 

--- a/tools/collect-manifests.sh
+++ b/tools/collect-manifests.sh
@@ -17,17 +17,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts 'd:t:h' opt; do
+SYSTEMS_YAML="config/systems.yaml"
+
+while getopts 's:d:t:h' opt; do
 case "$opt" in
 d) TREEDIR="$OPTARG" ;;
+s) SYSTEM_TYPE="$OPTARG" ;;
 t) TARFILE="$OPTARG" ;;
 \?|h)
-    echo "Usage: $0 -d NEW_DIR -t TARFILE_NAME"
+    echo "Usage: $0 -s SYSTEM_TYPE -d NEW_DIR -t TARFILE_NAME"
     echo
-    echo "  NEW_DIR        Directory to create tree of manifests. This directory"
-    echo "                 must not exist and must begin with a slash." 
-    echo "  TARFILE_NAME   Name to give to the tarfile of manifests. This name"
-    echo "                 must begin with a slash."
+    echo "  -d NEW_DIR       Directory to create tree of manifests. This"
+    echo "                   must not exist and must begin with a slash." 
+    echo "  -s SYSTEM_TYPE   Type of manifests to generate. Specify 'kind'"
+    echo "                   for K8s-in-Docker or 'rabbit' for real hardware."
+    echo "  -t TARFILE_NAME  Name to give to the tarfile of manifests. This"
+    echo "                   must begin with a slash."
     exit 1
     ;;
 esac
@@ -54,51 +59,113 @@ elif [[ -f $TARFILE ]]; then
     echo "The tarfile must not already exist"
     exit 1
 fi
+if [[ -z $SYSTEM_TYPE ]]; then
+    echo "You must specify -s"
+    exit 1
+elif [[ $SYSTEM_TYPE != "kind" && $SYSTEM_TYPE != "rabbit" ]]; then
+    echo "System type must be 'kind' or 'rabbit'"
+    exit 1
+fi
+
+set -e
+set -o pipefail
 
 mkdir "$TREEDIR"
 DO_MODULES=""
 SUBMODULES=$(git submodule status | awk '{print $2}')
 
-for SUBMODULE in $SUBMODULES; do
-    if grep -qE '^edit-image:' "$SUBMODULE"/Makefile
-    then
-        echo "Generating the manifest from $SUBMODULE"
-        if ! make -C "$SUBMODULE" edit-image kustomize; then
-            echo "Stopping at $SUBMODULE"
-            exit 1
-        fi
-        DO_MODULES="$DO_MODULES $SUBMODULE"
-    fi
-done
+get_overlays() {
+    local system_name="$1"
 
-for SUBMODULE in $DO_MODULES; do
-    echo "Collecting the manifest from $SUBMODULE"
-    mkdir "$TREEDIR/$SUBMODULE"
-    (cd "$SUBMODULE" || exit 1
-     if [[ -d config/begin ]]; then
-         # Remove the namespace from the manifest, because this manifest is
-         # used not only to deploy but also to undeploy.
-         # The namespace will be created by the ArgoCD Application resource,
-         # and nothing will delete it.
-         # Place the CRDs in a separate manifest.
-         bin/kustomize build config/begin | yq eval 'select(.kind != "Namespace" and .kind != "CustomResourceDefinition")' > "$TREEDIR/$SUBMODULE/$SUBMODULE.yaml"
-         bin/kustomize build config/begin | yq eval 'select(.kind == "CustomResourceDefinition")' > "$TREEDIR/$SUBMODULE/$SUBMODULE-crds.yaml"
-     fi
-     if [[ -d config/begin-examples ]]; then
-         bin/kustomize build config/begin-examples > "$TREEDIR/$SUBMODULE/$SUBMODULE-examples.yaml"
-     fi
-     if [[ -d config/prometheus ]]; then
-         bin/kustomize build config/prometheus > "$TREEDIR/$SUBMODULE/$SUBMODULE-prometheus.yaml"
-     fi
-     if [[ -d deploy/kubernetes/begin ]]; then
-         # Remove the namespace from the manifest, because this manifest is
-         # used not only to deploy but also to undeploy.
-         # The namespace will be created by the ArgoCD Application resource,
-         # and nothing will delete it.
-         bin/kustomize build deploy/kubernetes/begin | yq eval 'select(.kind != "Namespace")' > "$TREEDIR/$SUBMODULE/$SUBMODULE.yaml"
-     fi
-    )
-done
+    local overlays=""
+    if ! overlays=$(yq -M eval '.systems[]|select(.name=="'"$system_name"'")|.overlays|join(" ")' $SYSTEMS_YAML); then
+        echo "Unable to find overlays for $system_name"
+        exit 1
+    fi
+    echo "$overlays"
+}
+
+find_overlay_dir() {
+    local subdir="$1"
+    local system_name="$2"
+
+    local overlays=""
+    overlays=$(get_overlays "$system_name")
+    local ovlay="NONE"
+    for x in $overlays; do
+        if [[ -d $subdir/config/$x || -d $subdir/deploy/kubernetes/$x ]]; then
+            ovlay="$x"
+            break
+        fi
+    done
+    echo "$ovlay"
+}
+
+point_to_overlay() {
+    local system_name="$1"
+
+    for SUBMODULE in $SUBMODULES; do
+        OVLAY=$(find_overlay_dir "$SUBMODULE" "$system_name")
+        if grep -qE '^edit-image:' "$SUBMODULE"/Makefile
+        then
+            echo "Generating the manifest for overlay $OVLAY from $SUBMODULE"
+            if ! make OVERLAY="$OVLAY" -C "$SUBMODULE" edit-image kustomize; then
+                echo "Stopping at $SUBMODULE"
+                exit 1
+            fi
+            DO_MODULES="$DO_MODULES $SUBMODULE"
+        fi
+    done
+}
+
+collect_manifest() {
+    for SUBMODULE in $DO_MODULES; do
+        echo "Collecting the manifest from $SUBMODULE"
+        SUBMOD_DIR="$TREEDIR/$SUBMODULE"
+        mkdir "$SUBMOD_DIR"
+        (cd "$SUBMODULE" || exit 1
+         if [[ -d config/begin ]]; then
+             # Remove the namespace from the manifest, because this manifest is
+             # used not only to deploy but also to undeploy.
+             # The namespace will be created by the ArgoCD Application resource,
+             # and nothing will delete it.
+             # Place the CRDs in a separate manifest.
+             bin/kustomize build config/begin | yq eval 'select(.kind != "Namespace" and .kind != "CustomResourceDefinition")' > "$SUBMOD_DIR/$SUBMODULE.yaml"
+             bin/kustomize build config/begin | yq eval 'select(.kind == "CustomResourceDefinition")' > "$SUBMOD_DIR/$SUBMODULE-crds.yaml"
+         fi
+         if [[ -d config/begin-examples ]]; then
+             bin/kustomize build config/begin-examples > "$SUBMOD_DIR/$SUBMODULE-examples.yaml"
+         fi
+         if [[ -d config/prometheus ]]; then
+             bin/kustomize build config/prometheus > "$SUBMOD_DIR/$SUBMODULE-prometheus.yaml"
+         fi
+         if [[ -d deploy/kubernetes/begin ]]; then
+             # Remove the namespace from the manifest, because this manifest is
+             # used not only to deploy but also to undeploy.
+             # The namespace will be created by the ArgoCD Application resource,
+             # and nothing will delete it.
+             bin/kustomize build deploy/kubernetes/begin | yq eval 'select(.kind != "Namespace")' > "$SUBMOD_DIR/$SUBMODULE.yaml"
+         fi
+        )
+    done
+}
+
+walk_overlays() {
+    if [[ ! -f $SYSTEMS_YAML ]]; then
+        echo "Unable to find $SYSTEMS_YAML"
+        exit 1
+    fi
+
+    if [[ $SYSTEM_TYPE == 'kind' ]]; then
+        point_to_overlay kind
+        collect_manifest
+    else
+        point_to_overlay rabbit-tds
+        collect_manifest
+    fi
+}
+
+walk_overlays
 
 mkdir "$TREEDIR/cert-mgr"
 CERT_URL=$(yq -M '.thirdPartyServices[] | select(.name == "cert-manager") | .url' config/repositories.yaml)


### PR DESCRIPTION
When collecting a manifest, specify whether it is being collected for KIND or for hardware, and run the edit-image makefile target in each submodule to ensure that the desired type of manifest will be generated. Read the overlays list out of config/systems.yaml to find the appropriate overlay in each submodule for the desired type of manifest.

Add both manifests to the release artifacts.