### PR TITLE
Switch nnf-deploy init to install ArgoCD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ release-manifests-kind/
 manifests.tar
 manifests-kind.tar
 
+overlay-legacy.yaml
+
+

--- a/Readme.md
+++ b/Readme.md
@@ -80,11 +80,22 @@ Run "nnf-deploy <command> --help" for more information on a command.
 
 ## Init
 
-The `init` subcommand installs cert manager, mpi-operator, lustre-csi-driver,
-and lustre-fs-operator. This only needs to be done once on a new cluster or
-when one of them changes.
+The `init` subcommand will install ArgoCD via helm. The user must have the helm
+CLI installed and the argoproj helm repo added to their local cache. This init
+command should be done only once on a new cluster.
 
 ```bash
+./nnf-deploy init
+```
+
+To restore legacy init behavior--to have `init` install cert manager,
+mpi-operator, lustre-csi-driver, and lustre-fs-operator--copy the
+`config/overlay-legacy.yaml-template` file to `./overlay-legacy.yaml`. This init
+command only needs to be done once on a new cluster or when one of them
+changes.
+
+```bash
+cp config/overlay-legacy.yaml-template overlay-legacy.yaml
 ./nnf-deploy init
 ```
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -545,12 +545,20 @@ func installThirdPartyServices(ctx *Context) error {
 
 	for idx := range thirdPartyServices {
 		svc := thirdPartyServices[idx]
-		if !svc.UseRemoteF {
+		if svc.UseRemoteF {
+			fmt.Printf("Installing %s...\n", svc.Name)
+			if err := runKubectlApplyF(ctx, svc.Url); err != nil {
+				return err
+			}
+		} else if svc.UseHelm {
+			fmt.Printf("Installing %s...\n", svc.Name)
+			cmd := exec.Command("bash", "-c", svc.HelmCmd)
+			_, err = runCommand(ctx, cmd)
+			if err != nil {
+				return err
+			}
+		} else {
 			continue
-		}
-		fmt.Printf("Installing %s...\n", svc.Name)
-		if err := runKubectlApplyF(ctx, svc.Url); err != nil {
-			return err
 		}
 		if len(svc.WaitCmd) > 0 {
 			fmt.Println("  waiting for it to be ready...")

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// The legacy overlay reverts 'nnf-deploy init' to pre-helm behavior.
+var legacyOverlay string = "overlay-legacy.yaml"
+
 var sysCfgPath string
 
 type System struct {
@@ -217,6 +220,8 @@ type ThirdPartyService struct {
 	UseRemoteF bool   `yaml:"useRemoteF,omitempty"`
 	Url        string `yaml:"url"`
 	WaitCmd    string `yaml:"waitCmd,omitempty"`
+	UseHelm    bool   `yaml:"useHelm,omitempty"`
+	HelmCmd    string `yaml:"helmCmd,omitempty"`
 }
 
 func readConfigFile(configPath string) (*RepositoryConfigFile, error) {
@@ -241,6 +246,25 @@ func FindRepository(configPath string, module string) (*Repository, *BuildConfig
 		return nil, nil, err
 	}
 
+	mergeOverlay := true
+	configOverlay, err := readConfigFile(legacyOverlay)
+	if err != nil {
+		if os.IsNotExist(err) {
+			mergeOverlay = false
+		} else {
+			return nil, nil, err
+		}
+	}
+	if mergeOverlay {
+		for _, svc := range configOverlay.Repositories {
+			for idx := range config.Repositories {
+				if config.Repositories[idx].Name == svc.Name {
+					config.Repositories[idx].UseRemoteK = svc.UseRemoteK
+				}
+			}
+		}
+	}
+
 	for _, repository := range config.Repositories {
 		if module == repository.Name {
 			return &repository, &config.BuildConfig, nil
@@ -254,6 +278,26 @@ func GetThirdPartyServices(configPath string) ([]ThirdPartyService, error) {
 	config, err := readConfigFile(configPath)
 	if err != nil {
 		return nil, err
+	}
+	mergeOverlay := true
+	configOverlay, err := readConfigFile(legacyOverlay)
+	if err != nil {
+		if os.IsNotExist(err) {
+			mergeOverlay = false
+		} else {
+			return nil, err
+		}
+	}
+	if mergeOverlay {
+		for _, svc := range configOverlay.ThirdPartyServices {
+			for idx := range config.ThirdPartyServices {
+				if config.ThirdPartyServices[idx].Name == svc.Name {
+					config.ThirdPartyServices[idx].UseRemoteF = svc.UseRemoteF
+					config.ThirdPartyServices[idx].UseHelm = svc.UseHelm
+					break
+				}
+			}
+		}
 	}
 	return config.ThirdPartyServices, nil
 }

--- a/config/helm-values/argocd.yaml
+++ b/config/helm-values/argocd.yaml
@@ -1,0 +1,38 @@
+# An override for the argocd helm chart.
+#
+# helm repo add argo https://argoproj.github.io/argo-helm
+# helm repo update argo
+# helm search repo argocd
+# helm show values argo/argo-cd --version $CHART_VER > argocd.yaml
+#
+# helm install argocd -n argocd --create-namespace argo/argo-cd \
+#   --version $CHART_VER -f $THIS_OVERRIDE_FILE
+
+---
+global:
+  image:
+    tag: "v2.6.6"
+
+server:
+  extraArgs:
+    # Prevent argocd from generating self-cert and redirect http to https.
+    - --insecure
+    # "Instead, should use ingress and terminate https on the ingress level,
+    # then route plain http to argocd."
+
+configs:
+  cm:
+    resource.customizations.health.argoproj.io_Application: |
+      hs = {}
+      hs.status = "Progressing"
+      hs.message = ""
+      if obj.status ~= nil then
+        if obj.status.health ~= nil then
+          hs.status = obj.status.health.status
+          if obj.status.health.message ~= nil then
+            hs.message = obj.status.health.message
+          end
+        end
+      end
+      return hs
+

--- a/config/overlay-legacy.yaml-template
+++ b/config/overlay-legacy.yaml-template
@@ -1,0 +1,17 @@
+# This overlay restores config/repositories.yaml to its pre-helm behavior.
+# To enable this, copy it to the nnf-deploy root and nnf-deploy will recognize
+# it during `nnf-deploy init`:
+#   cp config/overlay-legacy.yaml-template ./overlay-legacy.yaml
+
+repositories:
+  - name: lustre-csi-driver
+    useRemoteK: true
+  - name: lustre-fs-operator
+    useRemoteK: true
+thirdPartyServices:
+  - name: cert-manager
+    useRemoteF: true
+  - name: mpi-operator
+    useRemoteF: true
+  - name: argocd
+    useHelm: false

--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -31,14 +31,14 @@ repositories:
     overlays: [overlays/rabbit, overlays/kind]
     development: https://ghcr.io/hewlettpackard/lustre-csi-driver
     master: https://ghcr.io/hewlettpackard/lustre-csi-driver
-    useRemoteK: true
+    useRemoteK: false
     remoteReference:
       build: master
       url: https://github.com/HewlettPackard/lustre-csi-driver.git/deploy/kubernetes/%s/?ref=%s
   - name: lustre-fs-operator
     development: https://ghcr.io/nearnodeflash/lustre-fs-operator
     master: https://ghcr.io/nearnodeflash/lustre-fs-operator
-    useRemoteK: true
+    useRemoteK: false
     remoteReference:
       build: master
       url: https://github.com/NearNodeFlash/lustre-fs-operator.git/config/default/?ref=%s
@@ -58,11 +58,16 @@ thirdPartyServices:
   # Other services that NNF requires to be available on the system.
   # They will be installed in the order specified here.
   - name: cert-manager
-    useRemoteF: true
+    useRemoteF: false
     url: https://github.com/jetstack/cert-manager/releases/download/v1.13.1/cert-manager.yaml
     # The NNF services will dump errors at installation time if the
     # cert-manager webhook isn't ready.
     waitCmd: kubectl wait deploy -n cert-manager --timeout=180s cert-manager-webhook --for jsonpath='{.status.availableReplicas}=1'
   - name: mpi-operator
-    useRemoteF: true
+    useRemoteF: false
     url: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.4.0/deploy/v2beta1/mpi-operator.yaml
+  - name: argocd
+    useHelm: true
+    helmCmd: helm install argocd -n argocd --create-namespace argo/argo-cd --version 3.35.4 -f config/helm-values/argocd.yaml
+    waitCmd: kubectl wait deploy -n argocd --timeout=180s argocd-server --for jsonpath='{.status.availableReplicas}=1'
+


### PR DESCRIPTION
The `nnf-deploy init` command will install ArgoCD via helm. The user must have the helm CLI installed and the argoproj helm repo added to their local cache.

The command will no longer install cert-manager, mpi-operator, lustre-csi-driver, or lustre-fs-operator at init time. Those will be handled from the ArgoCD gitops repo.

To restore legacy init behavior, copy the config/overlay-legacy.yaml-template file to ./overlay-legacy.yaml.