### PR TITLE
Set audit policy level to metadata

### DIFF
--- a/config/audit-policy.yaml
+++ b/config/audit-policy.yaml
@@ -25,7 +25,7 @@ omitStages:
 - RequestReceived
 
 rules:
-- level: RequestResponse
+- level: Metadata
   verbs: ["create", "patch", "update", "delete", "deletecollection"]
   resources:
 


### PR DESCRIPTION
Adjust the KIND audit policy to log only metadata, to reduce the size of the audit log.