### PR TITLE
deploy: fix reference to renamed storageprofile

### DIFF
--- a/tools/default-nnfstorageprofile.sh
+++ b/tools/default-nnfstorageprofile.sh
@@ -26,8 +26,8 @@ fi
 
 TMPIN=$(mktemp)
 
-if ! kubectl get nnfstorageprofile -n nnf-system placeholder -o json > "$TMPIN";  then
-    echo "Unable to retrieve NnfStorageProfile/placeholder"
+if ! kubectl get nnfstorageprofile -n nnf-system template -o json > "$TMPIN";  then
+    echo "Unable to retrieve NnfStorageProfile/template"
     rm -f "$TMPIN"
     exit 1
 fi


### PR DESCRIPTION
Problem: the 'placeholder' nnfstorageprofile was renamed to 'template' by PR #152.

Fix an old reference to 'placeholder'.