### PR TITLE
Require that go.mod, go.sum, vendor/modules.txt be up to date

### DIFF
--- a/tools/release-all/release-all.sh
+++ b/tools/release-all/release-all.sh
@@ -253,10 +253,8 @@ check_peer_modules() {
             go mod vendor || do_fail "${indent}Failure in go mod vendor"
         fi
 
-        # If the module update touched only go.mod, go.sum, or modules.txt then
-        # forget about it.
         # Let the user deal with any changes bigger than that.
-        if [[ $(git status -s | grep -c -v -e go.mod -e go.sum -e vendor/modules.txt) -gt 0 ]]; then
+        if [[ $(git status -s | wc -l) -gt 0 ]]; then
             msg "${indent}Peer modules are behind."
             msg "${indent}Update the modules and create a PR. I used:"
             echo
@@ -264,10 +262,6 @@ check_peer_modules() {
             echo
             exit 1
         fi
-
-        # It was only go.mod, go.sum, or modules.txt, so toss those.
-        git restore go.mod go.sum
-        [[ -f vendor/modules.txt ]] && git restore vendor/modules.txt
     fi
 }
 

--- a/tools/release-all/release-all.sh
+++ b/tools/release-all/release-all.sh
@@ -253,7 +253,6 @@ check_peer_modules() {
             go mod vendor || do_fail "${indent}Failure in go mod vendor"
         fi
 
-        # Let the user deal with any changes bigger than that.
         if [[ $(git status -s | wc -l) -gt 0 ]]; then
             msg "${indent}Peer modules are behind."
             msg "${indent}Update the modules and create a PR. I used:"


### PR DESCRIPTION
Originally, this tool didn't fuss if these files were the only thing out of date. However, this has allowed some merge conflicts to appear.