### PR TITLE
Allow kustomize examples to be bumped by crd-bumper

### DIFF
--- a/tools/crd-bumper/crd-bumper.py
+++ b/tools/crd-bumper/crd-bumper.py
@@ -335,9 +335,13 @@ def bump_controllers(cgen, makecmd, git, stage, project, args, bumper_cfg):
     controllers.edit_util_conversion_test()
 
     # Bump any other, non-controller, directories of code.
-    if bumper_cfg is not None and 'extra_go_dirs' in bumper_cfg:
+    if bumper_cfg is not None and "extra_go_dirs" in bumper_cfg:
         for extra_dir in bumper_cfg["extra_go_dirs"].split(","):
             controllers.update_extras(extra_dir)
+    # Bump any necessary references in the config/ dir.
+    if bumper_cfg is not None and "extra_config_dirs" in bumper_cfg:
+        for extra_dir in bumper_cfg["extra_config_dirs"].split(","):
+            controllers.update_extra_config(extra_dir)
 
     makecmd.fmt()
     controllers.commit_bump_controllers(git, stage)

--- a/tools/crd-bumper/pkg/conversion_gen.py
+++ b/tools/crd-bumper/pkg/conversion_gen.py
@@ -102,13 +102,6 @@ class ConversionGen:
         )
         fu.store()
 
-        # for root, _, f_names in os.walk(f"api/{self._new_ver}", followlinks=False):
-        #  for fname in f_names:
-        #    full_path = os.path.join(root, fname)
-        #    fu = FileUtil(self._dryrun, full_path)
-        #    fu.replace_in_file(f"{group}{self._new_ver}", f"{self._preferred_alias}{self._new_ver}")
-        #    fu.store()
-
     def module(self):
         """Return the name of this Go module."""
 
@@ -389,6 +382,7 @@ func TestFuzzyConversion(t *testing.T) {{
             fu.append(template)
 
         # Wake up!  Multi-line f-string:
+        # pylint: disable=f-string-without-interpolation
         template = f"""
 }}
 


### PR DESCRIPTION
Allow the repo-local config file to specify a comma-separated list of directories of Kustomize config files that have references to the API and that must be updated to the new hub version so that ArgoCD can sync them.