### PR TITLE
Ignore old versions when vendoring new API

### DIFF
--- a/tools/crd-bumper/README.md
+++ b/tools/crd-bumper/README.md
@@ -63,11 +63,11 @@ Vendor this new API into another repository using the `vendor-new-api` tool. Thi
 
 ### Executing the Tool
 
-The following example will vendor the new `v1beta2` API we created above for lustre-fs-operator into the nnf-sos repository. The module representing lustre-fs-operator is specified in the same form that it would appear in the `go.mod` file in nnf-sos. It begins by creating a new branch in nnf-sos off "master" named `api-lustre-fs-operator-v1beta2`, where it will do all of its work.
+The following example will vendor the new `v1beta2` API we created above for lustre-fs-operator into the nnf-sos repository. The current hub version for nnf-sos is `v1alpha3`, and is specified with the `--hub-ver` option. The module representing lustre-fs-operator is specified in the same form that it would appear in the `go.mod` file in nnf-sos. The `--version` option can be used to specify a version if necessary. It begins by creating a new branch in nnf-sos off "master" named `api-lustre-fs-operator-v1beta2`, where it will do all of its work.
 
 ```console
 DEST_REPO=git@github.com:NearNodeFlash/nnf-sos.git
-vendor-new-api.py -r $DEST_REPO --hub-ver v1beta2 --module github.com/NearNodeFlash/lustre-fs-operator
+vendor-new-api.py -r --hub-ver v1alpha3 $DEST_REPO --vendor-hub-ver v1beta2 --module github.com/NearNodeFlash/lustre-fs-operator --version master
 ```
 
 The repository with its new API will be found under a directory named `workingspace/nnf-sos`.

--- a/tools/crd-bumper/vendor-new-api.py
+++ b/tools/crd-bumper/vendor-new-api.py
@@ -39,11 +39,25 @@ PARSER.add_argument(
     help="Version of the hub API.",
 )
 PARSER.add_argument(
+    "--vendor-hub-ver",
+    type=str,
+    required=True,
+    help="Version of the hub API for the repo being vendored.",
+)
+PARSER.add_argument(
     "--module",
     "-m",
     type=str,
     required=True,
     help="Go module which has the versioned API, specified the way it is found in go.mod.",
+)
+PARSER.add_argument(
+    "--version",
+    "-v",
+    type=str,
+    required=False,
+    default="master",
+    help="Version for the go module which has the versioned API",
 )
 PARSER.add_argument(
     "--repo",
@@ -128,7 +142,7 @@ def main():
 def vendor_new_api(args, makecmd, git, gocli, bumper_cfg):
     """Vendor the new API into the repo."""
 
-    vendor = Vendor(args.dryrun, args.module, args.hub_ver)
+    vendor = Vendor(args.dryrun, args.module, args.hub_ver, args.vendor_hub_ver)
 
     if vendor.uses_module() is False:
         print(
@@ -156,10 +170,9 @@ def vendor_new_api(args, makecmd, git, gocli, bumper_cfg):
         for extra_dir in bumper_cfg["extra_config_dirs"].split(","):
             vendor.update_config_files(extra_dir)
 
-    gocli.get(args.module, "master")
+    gocli.get(args.module, args.version)
     gocli.tidy()
     gocli.vendor()
-    vendor.verify_one_api_version()
 
     makecmd.manifests()
     makecmd.generate()


### PR DESCRIPTION
Change the vendor-new-api.py script to only vendor a new API for the latest API in the target repo. Old API versions may have embedded structs from a vendor API, and we don't want them to change.

Also, add an option to specify which version of the vendor API to "go get".