### PR TITLE
Allow vendoring into nnf-integration-test repo

### DIFF
--- a/tools/crd-bumper/pkg/conversion_gen.py
+++ b/tools/crd-bumper/pkg/conversion_gen.py
@@ -38,19 +38,6 @@ class ConversionGen:
         self.module()
         self._preferred_alias = self.set_preferred_api_alias()
 
-    def is_spoke(self, ver):
-        """
-        Determine whether or not the 'ver' API is a spoke.
-        """
-        path = f"api/{ver}/conversion.go"
-        if not os.path.isfile(path):
-            return False
-        fu = FileUtil(self._dryrun, path)
-        line = fu.find_in_file(" ConvertTo(dstRaw conversion.Hub) ")
-        if line is None:
-            return False
-        return True
-
     def preferred_api_alias(self):
         """Return the preferred alias."""
         return self._preferred_alias

--- a/tools/crd-bumper/pkg/create_apis.py
+++ b/tools/crd-bumper/pkg/create_apis.py
@@ -22,6 +22,7 @@ import shutil
 
 from .project import Project
 from .fileutil import FileUtil
+from .hub_spoke_util import HubSpokeUtil
 
 
 class CreateApis:
@@ -45,14 +46,7 @@ class CreateApis:
 
         for _, dir_names, _ in os.walk("api", followlinks=False):
             if len(dir_names) > 1:
-                path = f"api/{self._prev_ver}/conversion.go"
-                if not os.path.isfile(path):
-                    return False
-                fu = FileUtil(self._dryrun, path)
-                line = fu.find_in_file(" Hub() ")
-                if line is None:
-                    return False
-                break
+                return HubSpokeUtil.is_hub(self._prev_ver)
         return True
 
     def create(self):

--- a/tools/crd-bumper/pkg/hub_spoke_util.py
+++ b/tools/crd-bumper/pkg/hub_spoke_util.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from .fileutil import FileUtil
+
+
+class HubSpokeUtil:
+    """Simple utilities related to hub and spokes."""
+
+    @staticmethod
+    def is_spoke(ver):
+        """
+        Determine whether or not the 'ver' API is a spoke.
+        """
+        path = f"api/{ver}/conversion.go"
+        if not os.path.isfile(path):
+            return False
+        fu = FileUtil(False, path)
+        line = fu.find_in_file(" ConvertTo(dstRaw conversion.Hub) ")
+        if line is None:
+            return False
+        return True
+
+    @staticmethod
+    def is_hub(ver):
+        """
+        Determine whether or not the 'ver' API is a hub.
+        """
+        path = f"api/{ver}/conversion.go"
+        if not os.path.isfile(path):
+            return False
+        fu = FileUtil(False, path)
+        line = fu.find_in_file(" Hub() ")
+        if line is None:
+            return False
+        return True

--- a/tools/crd-bumper/unserve.py
+++ b/tools/crd-bumper/unserve.py
@@ -27,6 +27,7 @@ from pkg.git_cli import GitCLI
 from pkg.make_cmd import MakeCmd
 from pkg.project import Project
 from pkg.unserve import Unserve
+from pkg.hub_spoke_util import HubSpokeUtil
 
 WORKING_DIR = "workingspace"
 BRANCH_SUFFIX = "unserve"
@@ -109,7 +110,7 @@ def main():
             )
             sys.exit(1)
 
-    if not cgen.is_spoke(args.spoke_ver):
+    if not HubSpokeUtil.is_spoke(args.spoke_ver):
         print(f"API --spoke-ver {args.spoke_ver} is not a spoke.")
         sys.exit(1)
 


### PR DESCRIPTION
Adjust vendor-new-api.py so it can vendor into the nnf-integration-test repo. This relies on a new crd-bumper.yaml file in that repo to give some hints.

Refactor code that checks whether an API is a hub or a spoke.

Refactor code that references the crd-bumper.yaml file. This simplifies the use of the object that holds the content of that file.

Reformat code with 'black'.