### PR TITLE
Enhance dry-run with install

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
Allow dry-run to run some things that don't modify the target node, and add a dry-run-always to prevent even that much.

Add some vertical whitespace to the output to make it easier to follow.