### PR TITLE
Vendor-new-api needs help finding module aliases

### DIFF
--- a/tools/crd-bumper/Editing_APIs.md
+++ b/tools/crd-bumper/Editing_APIs.md
@@ -8,7 +8,6 @@ In the DWS repository, add a new field to the `Status` section of the `SystemCon
 
 ### Step 1: Add a new ResourceError field
 
-
 ```go
 diff --git a/api/v1alpha2/systemconfiguration_types.go b/api/v1alpha2/systemconfiguration_types.go
 index 3e4d29fb..2c65e3a0 100644

--- a/tools/crd-bumper/pkg/fileutil.py
+++ b/tools/crd-bumper/pkg/fileutil.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -49,7 +49,7 @@ class FileUtil:
                 os.rename(f"{self._fpath}.new", self._fpath)
 
     def replace_in_file(self, from_str, to_str):
-        """Replace one string with another throughout the file."""
+        """Replace one string with another."""
 
         self.read()
         changed = False

--- a/tools/crd-bumper/vendor-new-api.py
+++ b/tools/crd-bumper/vendor-new-api.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -163,10 +163,10 @@ def vendor_new_api(args, makecmd, git, gocli, bumper_cfg):
             gocli.tidy()
             gocli.vendor()
         vendor.set_current_api_version()
-        main_file = None
+        alt_main_file = None
         if "alternate_main" in bumper_cfg:
-            main_file = bumper_cfg["alternate_main"]
-        vendor.set_preferred_api_alias(main_file)
+            alt_main_file = bumper_cfg["alternate_main"]
+        vendor.set_preferred_api_alias(alt_main_file)
     except ValueError as ex:
         print(str(ex))
         sys.exit(1)


### PR DESCRIPTION
Let the 'alternate_main' field from the crd-bumper.yaml be used as a supplement, rather than as a replacement, when trying to figure out the alias that is used for a module import.