### PR TITLE
Let crd-bumper identify carry-over code for conversions

### DIFF
--- a/tools/crd-bumper/README.md
+++ b/tools/crd-bumper/README.md
@@ -148,6 +148,16 @@ Used in `internal/controller/conversion_test.go` to indicate where additional te
 
 Used in `internal/controller/conversion_test.go` to indicate where additional spoke conversion tests should be placed. Each kind will have its own `Context()` block within the main `Describe()`, and this should be the last statement within each of those Context blocks. Replace "GROUP.KIND" with the API's group and kind, using the same spelling and use of lower/upper case letters as found in the `./PROJECT` file.
 
+**+crdbumper:carryforward:begin="KIND.DIRECTION"**
+
+**+crdbumper:carryforward:begin="Epilog"**
+
+Used in `api/$SPOKE/conversion.go` to indicate that a segment of code should be carried forward as new spokes are created or as old spokes are removed. Use of this marker should be uncommon; it's almost always wrong to carry-forward code to a new spoke. Replace "KIND" with the API's kind, using the same spelling and use of lower/upper case letters as found in the `./PROJECT` file. Replace "DIRECTION" with "ConvertFrom" or "ConvertTo" to mark the section of code as being in a `ConvertFrom()` or `ConvertTo()` function. If the "Epilog" variation is used then this marks one or more `Convert_$API1_$KIND_To_$API2_$KIND()` conversion functions, or similar chunks of code, that are typically collected at the end of `conversion.go`.
+
+**+crdbumper:carryforward:end**
+
+This is used in `api/$SPOKE/conversion.go` to close the segment of code that was marked with `+crdbumper:carryforward:begin`.
+
 ## References
 
 ### Kubernetes

--- a/tools/crd-bumper/pkg/fileutil.py
+++ b/tools/crd-bumper/pkg/fileutil.py
@@ -85,6 +85,19 @@ class FileUtil:
                     return line
         return None
 
+    def find_all_in_file(self, substr):
+        """Find all lines, with line numbers, having a given substring."""
+
+        self.read()
+        cnt = 1
+        output = []
+        if self._input_data is not None:
+            for line in self._input_data.split("\n"):
+                if substr in line:
+                    output.append([cnt, line])
+                cnt += 1
+        return output
+
     def find_with_pattern(self, pat):
         """Find the first line matching a given pattern."""
 

--- a/tools/crd-bumper/pkg/vendoring.py
+++ b/tools/crd-bumper/pkg/vendoring.py
@@ -96,7 +96,7 @@ class Vendor:
                 if m is not None:
                     self._preferred_alias = m.group(1)
 
-        fnames=["cmd/main.go"]
+        fnames = ["cmd/main.go"]
         search_for_alias("cmd/main.go")
         if self._preferred_alias is None:
             fnames.append(alt_main_file)


### PR DESCRIPTION
Define a new code marker to place around conversion code that must be carried over to a new spoke. This should be used infrequently--it's almost always wrong to carry over conversion code to a newly-created spoke.

This does not yet copy the marked code over to the new spoke, but it does allow that code to be marked and it does find it and print out a banner about it.