### PR TITLE
Allow vendor-new-api to vendor multi API versions from one repo

### DIFF
--- a/tools/crd-bumper/pkg/vendoring.py
+++ b/tools/crd-bumper/pkg/vendoring.py
@@ -24,13 +24,14 @@ from .fileutil import FileUtil
 class Vendor:
     """Tools for vendoring a new API version."""
 
-    def __init__(self, dryrun, module, hub_ver, vendor_hub_ver):
+    def __init__(self, dryrun, module, hub_ver, vendor_hub_ver, multi_vend=False):
         self._dryrun = dryrun
         self._module = module
         self._hub_ver = hub_ver
         self._vendor_hub_ver = vendor_hub_ver
         self._current_ver = None
         self._preferred_alias = None
+        self._multi_vend = multi_vend
 
     def current_api_version(self):
         """Return the current in-use API version."""
@@ -56,6 +57,16 @@ class Vendor:
                 # Only one API vendored here.
                 self._current_ver = dir_names[0]
                 break
+            if len(dir_names) > 1 and self._multi_vend:
+                # Multiple APIs are vendored here, and the user wants us to allow
+                # it. Verify that the desired version is one of them.
+                for dname in dir_names:
+                    if dname == self._vendor_hub_ver:
+                        self._current_ver = dname
+                        print("Multiple APIs have been allowed with -M, continuing")
+                        break
+                if self._current_ver is not None:
+                    break
             raise ValueError(
                 f"Expected to find one API at {path}, but found {len(dir_names)}."
             )

--- a/tools/crd-bumper/vendor-new-api.py
+++ b/tools/crd-bumper/vendor-new-api.py
@@ -154,7 +154,9 @@ def main():
 def vendor_new_api(args, makecmd, git, gocli, bumper_cfg):
     """Vendor the new API into the repo."""
 
-    vendor = Vendor(args.dryrun, args.module, args.hub_ver, args.vendor_hub_ver, args.multi_vend)
+    vendor = Vendor(
+        args.dryrun, args.module, args.hub_ver, args.vendor_hub_ver, args.multi_vend
+    )
 
     if vendor.uses_module() is False:
         print(

--- a/tools/crd-bumper/vendor-new-api.py
+++ b/tools/crd-bumper/vendor-new-api.py
@@ -24,7 +24,6 @@ import os
 import sys
 import yaml
 
-from pkg.conversion_gen import ConversionGen
 from pkg.git_cli import GitCLI
 from pkg.make_cmd import MakeCmd
 from pkg.vendoring import Vendor
@@ -102,6 +101,12 @@ PARSER.add_argument(
     default=WORKING_DIR,
     help=f"Name for working directory. All repos will be cloned below this directory. Default: {WORKING_DIR}.",
 )
+PARSER.add_argument(
+    "-M",
+    action="store_true",
+    dest="multi_vend",
+    help="Allow multiple API versions to be vendored from a single peer module. Expect this to be an unusual case.",
+)
 
 
 def main():
@@ -149,7 +154,7 @@ def main():
 def vendor_new_api(args, makecmd, git, gocli, bumper_cfg):
     """Vendor the new API into the repo."""
 
-    vendor = Vendor(args.dryrun, args.module, args.hub_ver, args.vendor_hub_ver)
+    vendor = Vendor(args.dryrun, args.module, args.hub_ver, args.vendor_hub_ver, args.multi_vend)
 
     if vendor.uses_module() is False:
         print(


### PR DESCRIPTION
This ought to be an unusual case, so you have to explicitly ask for it.