### PR TITLE
Allow vendor-new-api to vendor multi API versions from one repo

### DIFF
--- a/tools/crd-bumper/pkg/vendoring.py
+++ b/tools/crd-bumper/pkg/vendoring.py
@@ -24,7 +24,16 @@ from .fileutil import FileUtil
 class Vendor:
     """Tools for vendoring a new API version."""
 
-    def __init__(self, dryrun, module, hub_ver, vendor_hub_ver, multi_vend=False):
+    def __init__(
+        self,
+        dryrun,
+        module,
+        hub_ver,
+        vendor_hub_ver,
+        multi_vend=False,
+        vendor_prev_hub_ver=None,
+    ):
+        """Init"""
         self._dryrun = dryrun
         self._module = module
         self._hub_ver = hub_ver
@@ -32,6 +41,7 @@ class Vendor:
         self._current_ver = None
         self._preferred_alias = None
         self._multi_vend = multi_vend
+        self._vendor_prev_hub_ver = vendor_prev_hub_ver
 
     def current_api_version(self):
         """Return the current in-use API version."""
@@ -59,9 +69,9 @@ class Vendor:
                 break
             if len(dir_names) > 1 and self._multi_vend:
                 # Multiple APIs are vendored here, and the user wants us to allow
-                # it. Verify that the desired version is one of them.
+                # it. Verify that the indicated previous hub version is one of them.
                 for dname in dir_names:
-                    if dname == self._vendor_hub_ver:
+                    if dname == self._vendor_prev_hub_ver:
                         self._current_ver = dname
                         print("Multiple APIs have been allowed with -M, continuing")
                         break

--- a/tools/crd-bumper/vendor-new-api.py
+++ b/tools/crd-bumper/vendor-new-api.py
@@ -107,12 +107,22 @@ PARSER.add_argument(
     dest="multi_vend",
     help="Allow multiple API versions to be vendored from a single peer module. Expect this to be an unusual case.",
 )
+PARSER.add_argument(
+    "--vendor-prev-hub-ver",
+    type=str,
+    required=True,
+    help="Version of the previous hub API for the repo being vendored. Requires -M. Expect this to be an unusual case.",
+)
 
 
 def main():
     """main"""
 
     args = PARSER.parse_args()
+
+    if args.vendor_prev_hub_ver and not args.multi_vend:
+        print("Option --vendor-prev-hub-ver requires -M.")
+        sys.exit(1)
 
     gitcli = GitCLI(args.dryrun, args.nocommit)
     gitcli.clone_and_cd(args.repo, args.workdir)
@@ -155,7 +165,12 @@ def vendor_new_api(args, makecmd, git, gocli, bumper_cfg):
     """Vendor the new API into the repo."""
 
     vendor = Vendor(
-        args.dryrun, args.module, args.hub_ver, args.vendor_hub_ver, args.multi_vend
+        args.dryrun,
+        args.module,
+        args.hub_ver,
+        args.vendor_hub_ver,
+        args.multi_vend,
+        args.vendor_prev_hub_ver,
     )
 
     if vendor.uses_module() is False:


### PR DESCRIPTION
Force the user to tell us which of the existing APIs was the previous hub; because the symver libraries do not sort API version names for us.