### PR TITLE
Allow vendor-new-api to vendor multi API versions from one repo

### DIFF
--- a/tools/crd-bumper/vendor-new-api.py
+++ b/tools/crd-bumper/vendor-new-api.py
@@ -110,7 +110,6 @@ PARSER.add_argument(
 PARSER.add_argument(
     "--vendor-prev-hub-ver",
     type=str,
-    required=True,
     help="Version of the previous hub API for the repo being vendored. Requires -M. Expect this to be an unusual case.",
 )
 


### PR DESCRIPTION
Make --vendor-prev-hub-ver an optional arg, not required.