### PR TITLE
tools/kind.sh: split CA bundle into individual certs to silence c_rehash warnings

### DIFF
--- a/tools/kind.sh
+++ b/tools/kind.sh
@@ -122,8 +122,17 @@ function inject_ca_certs {
 
     echo "Injecting CA certificates from $certs into KIND nodes..."
     for node in $(kind get nodes); do
-        docker cp "$certs" "$node:/usr/local/share/ca-certificates/extra-ca-certs.crt"
-        docker exec "$node" update-ca-certificates
+        # Pipe the bundle via stdin and split into individual .crt files so that
+        # update-ca-certificates / c_rehash does not emit
+        # "skipping ... it does not contain exactly one certificate or CRL".
+        docker exec -i "$node" bash -c '
+            awk "/-----BEGIN CERTIFICATE-----/{n++; f=sprintf(\"/usr/local/share/ca-certificates/extra-ca-cert-%d.crt\",n)} f{print > f}"
+        ' < "$certs"
+        # The ca-certificates.crt bundle always triggers a benign c_rehash warning;
+        # filter it so only real warnings surface.
+        local uca_out
+        uca_out=$(docker exec "$node" update-ca-certificates 2>&1)
+        echo "$uca_out" | grep -Fv "skipping ca-certificates.crt" || true
         docker exec "$node" systemctl restart containerd
         echo "  $node: done"
     done


### PR DESCRIPTION
update-ca-certificates runs c_rehash, which requires exactly one certificate per file.
Injecting a multi-cert PEM bundle as a single .crt file caused spurious warnings on every kind.sh create.
Fix: pipe the bundle via stdin and split it with awk into individual extra-ca-cert-N.crt files before running update-ca-certificates.